### PR TITLE
init: width 값 모바일에 맞춰 설정하기

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import "@/styles/globals.css";
+import "@/styles/reset.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
@@ -5,11 +7,11 @@ const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "GreenSpark",
-  description: "그린스파크",
+  description: "그린스파크"
 };
 
 export default function RootLayout({
-  children,
+  children
 }: Readonly<{
   children: React.ReactNode;
 }>) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
 export default function Page() {
-  var hyun = "하이";
   return <div>Hello World</div>;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,27 +1,31 @@
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #000000;
+  --html-background: #e4e4e4;
   --vh: 100%;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html,
+body {
+  padding: 0;
+  margin: 0;
+  height: 100%;
+}
+
+html {
+  font-size: 62.5%;
+  background-color: var(--html-background);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
 }
 
 body {
   color: var(--foreground);
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
-}
-
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
-}
-html {
-  font-size: 62.5%;
+  max-width: 375px;
+  width: 100%;
+  min-height: 100vh;
 }


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #3 

## ✅ 작업 목록
- width 값 모바일에 맞춰 설정

## 🍰 논의사항
```
@media (prefers-color-scheme: dark) {
  :root {
    --background: #0a0a0a;
    --foreground: #ededed;
  }
```
이 코드는 현재 단계에서 불필요할 것 같아 주석처리 했습니다. 기획 단계에서 아직 다크모드 이야기가 논의되지 않은 것으로 알고 있어 추후에 다크모드 대응 얘기가 나오면 이 부분 논의하면 좋을 것 같습니다.

## 📷 ETC
1440px일 때
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/b3441c88-79e9-46f7-b2c7-d3ed27587539">

375px일 때
<img width="478" alt="image" src="https://github.com/user-attachments/assets/2343a831-976d-4db1-87ff-dbbbe590d918">


