### PR TITLE
fix: 새로고침 시 스타일 적용 안 되는 오류 해결

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  compiler: {
+    styledComponents: true
+  }
 };
 
 export default nextConfig;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "@/styles/reset.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import BottomNav from "@/components/bottomNav";
+import StyledComponentsRegistry from "@/lib/registry";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -20,9 +21,11 @@ export default function RootLayout({
     <>
       <html lang="ko">
         <body className={inter.className}>
-          <div>레이아웃</div>
-          {children}
-          <BottomNav />
+          <StyledComponentsRegistry>
+            <div>레이아웃</div>
+            {children}
+            <BottomNav />
+          </StyledComponentsRegistry>
         </body>
       </html>
     </>

--- a/src/lib/registry.tsx
+++ b/src/lib/registry.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import React, { useState } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import { ServerStyleSheet, StyleSheetManager } from "styled-components";
+
+export default function StyledComponentsRegistry({ children }: { children: React.ReactNode }) {
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== "undefined") return <>{children}</>;
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>{children}</StyleSheetManager>
+  );
+}


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
<!-- ex) close #1 -->
close #8 

## ✅ 작업 목록
<!-- 이슈 작업한 내용 -->
lib/registry.tsx 파일을 만들어 styled-components의 서버 사이드 렌더링(SSR) 설정을 통해 Next.js 앱에서 초기 스타일 플래싱 문제를 해결했습니다. 저희 프로젝트에서 App Router 방식을 사용하고 있기 때문에 (_document.js 지원 안 됨) 코드에서 클라이언트 컴포넌트를 사용해 SSR 설정을 직접 처리했습니다.

registry에서 StyledComponentsRegistry 만들기
1. ```"use client"```로 StyledComponentsRegistry를 클라이언트 컴포넌트로 지정하여 Next.js의 서버 컴포넌트 환경에서도 styled-components를 사용할 수 있게 했습니다.

2. ```const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());```를 이용해 스타일 시트를 생성했습니다. ServerStyleSheet 인스턴스를 생성하여 서버에서 스타일을 미리 렌더링하고 클라이언트가 받을 수 있도록 합니다. 이렇게 하면 서버에서 스타일을 한 번 생성하고 클라이언트에서 재사용하게 됩니다.

3. useServerInsertedHTML로 서버에 스타일을 삽입했습니다.

```
useServerInsertedHTML(() => {
  const styles = styledComponentsStyleSheet.getStyleElement();
  styledComponentsStyleSheet.instance.clearTag();
  return <>{styles}</>;
});
```

useServerInsertedHTML 훅은 서버에서 HTML이 처음 렌더링될 때 스타일을 삽입하는 데 사용됩니다. getStyleElement()는 서버에서 생성된 스타일 요소를 가져와 삽입하고, clearTag()를 통해 메모리 정리를 수행합니다. 이렇게 서버에서 스타일이 포함된 HTML을 클라이언트에게 전달하도록 바꿔줬습니다.

4. 클라이언트 환경에서는 StyleSheetManager가 스타일을 관리하며, 서버에서 생성한 스타일 시트가 클라이언트로 전달된 후에도 동일하게 스타일이 적용되도록 했습니다.

```
return (
  <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
    {children}
  </StyleSheetManager>
);
```


이후 StyledComponentsRegistry 컴포넌트로 불러와 children을 감싸는 구조로 변경하여, 모든 자식 컴포넌트에 스타일이 적용되도록 했습니다. 그리고 styled-components가 Next.js에서 제대로 작동하도록 컴파일러 옵션을 활성화했습니다.


## 🍰 논의사항
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->
styled-components가 CSS in JS라 Hydrate 과정에서 다운로드 받은 JS를 통해 지정된 스타일 정보가 생기기 때문에 페이지 로드 시 스타일이 잠깐 누락되어 발생하는 문제였습니다.

## 📷 ETC
<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
https://github.com/user-attachments/assets/c1f5ee38-e9eb-42c9-ac66-3f9e39b998e6

참고 아티클 
- https://lvd-hy.tistory.com/97


