### PR TITLE
Fix/power bottom nav change unit

### DIFF
--- a/src/app/_component/powerinput/PowerTable.module.css
+++ b/src/app/_component/powerinput/PowerTable.module.css
@@ -7,33 +7,33 @@
   color: #929292;
   text-align: center;
   font-family: Pretendard;
-  font-size: 10px;
+  font-size: 1rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
-  margin-bottom: 10px;
+  margin-bottom: 1rem;
 }
 .tableContainer {
   text-align: center;
-  width: 318px;
+  width: 31.8rem;
   border-collapse: collapse;
   background-color: white;
-  border-radius: 15px;
+  border-radius: 1.5em;
   overflow: hidden;
   border: none;
   border: var(--sds-size-stroke-border) solid #fff;
 
-  box-shadow: 0px 1px 8px 0px var(--Main-Color, #d7f3c6);
+  box-shadow: 0 0.1rem 0.8rem 0 var(--Main-Color, #d7f3c6);
 }
 
 .tableHead th {
-  padding: 8px;
+  padding: 0.8em;
   background: #d7f3c6;
   text-align: left;
   color: #5e5e5e;
   text-align: center;
   font-family: Pretendard;
-  font-size: 12px;
+  font-size: 1.2rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
@@ -41,31 +41,31 @@
 }
 
 .tableRow td {
-  padding: 9px 0;
+  padding: 0.9em 0;
   /* height: 30px; */
-  border-bottom: 1px solid #f1f3f5;
+  border-bottom: 0.1em solid #f1f3f5;
   color: #000;
   text-align: center;
   justify-content: center;
   font-family: Pretendard;
-  font-size: 12px;
+  font-size: 1.2rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
 }
 
 .yearCell {
-  width: 80px;
+  width: 8rem;
   color: #929292 !important;
   font-size: 10px !important;
 }
 
 .costUsageDivider {
-  border-left: 2px solid#F1F3F5; /* 년도와 전기요금 사이의 줄 */
+  border-left: 0.2em solid#F1F3F5; /* 년도와 전기요금 사이의 줄 */
 }
 .plusIcon {
-  width: 11px;
-  height: 11px;
+  width: 1.1rem;
+  height: 1.1rem;
 }
 
 .yearHeader {
@@ -76,29 +76,29 @@
 }
 
 .dropDownIcon {
-  margin-left: 5px;
-  width: 18px;
-  height: 18px;
+  margin-left: 0.5em;
+  width: 1.8rem;
+  height: 1.8rem;
 }
 
 .dropdownMenu {
-  width: 100px;
+  width: 10rem;
   position: absolute;
-  top: 60px;
-  border-radius: 10px;
-  border: 1px solid #b6ec94;
-  box-shadow: 0px 1px 8px 0px #d7f3c6;
+  top: 6rem;
+  border-radius: 1em;
+  border: 0.1em solid #b6ec94;
+  box-shadow: 0 0.1rem 0.8rem 0 #d7f3c6;
   background: #fff;
   z-index: 100;
-  padding: 10px 0;
+  padding: 1rem 0;
 }
 
 .dropdownItem {
-  padding: 8px 12px;
+  padding: 0.8em 1.2em;
   cursor: pointer;
   color: #5e5e5e;
   font-family: Pretendard;
-  font-size: 12px;
+  font-size: 1.2rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;

--- a/src/app/_component/powerinput/PowerTable.module.css
+++ b/src/app/_component/powerinput/PowerTable.module.css
@@ -1,7 +1,7 @@
 .tableWrap {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  /* justify-content: center; */
   align-items: center;
 
   width: 100%;

--- a/src/app/_component/powerinput/PowerTable.module.css
+++ b/src/app/_component/powerinput/PowerTable.module.css
@@ -1,7 +1,6 @@
 .tableWrap {
   display: flex;
   flex-direction: column;
-  /* justify-content: center; */
   align-items: center;
 
   width: 100%;
@@ -50,6 +49,7 @@
 }
 
 .tableRow td {
+  height: 15px;
   padding: 0.9em 0;
   border-bottom: 0.1em solid #f1f3f5;
 
@@ -77,8 +77,8 @@
 }
 
 .plusIcon {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .yearHeader {
@@ -128,5 +128,11 @@
 
 .dropdownbtn {
   display: flex;
+  align-items: center;
+}
+.iconWrapper {
+  height: 12px;
+  display: flex;
+  justify-content: center;
   align-items: center;
 }

--- a/src/app/_component/powerinput/PowerTable.module.css
+++ b/src/app/_component/powerinput/PowerTable.module.css
@@ -1,9 +1,18 @@
 .tableWrap {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
+
+  width: 100%;
+  min-height: 472px;
+
+  background-color: #f8fff3;
 }
+
 .tableName {
+  margin-bottom: 1rem;
+
   color: #929292;
   text-align: center;
   font-family: Pretendard;
@@ -11,58 +20,62 @@
   font-style: normal;
   font-weight: 400;
   line-height: normal;
-  margin-bottom: 1rem;
 }
+
 .tableContainer {
-  text-align: center;
   width: 31.8rem;
-  border-collapse: collapse;
-  background-color: white;
   border-radius: 1.5em;
+  border-collapse: collapse;
   overflow: hidden;
-  border: none;
   border: var(--sds-size-stroke-border) solid #fff;
 
+  background-color: white;
   box-shadow: 0 0.1rem 0.8rem 0 var(--Main-Color, #d7f3c6);
 }
 
 .tableHead th {
   padding: 0.8em;
+
   background: #d7f3c6;
-  text-align: left;
-  color: #5e5e5e;
   text-align: center;
+  color: #5e5e5e;
+
   font-family: Pretendard;
   font-size: 1.2rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+
   justify-content: center;
 }
 
 .tableRow td {
   padding: 0.9em 0;
-  /* height: 30px; */
   border-bottom: 0.1em solid #f1f3f5;
+
   color: #000;
   text-align: center;
-  justify-content: center;
+
   font-family: Pretendard;
   font-size: 1.2rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
+
+  justify-content: center;
 }
 
 .yearCell {
   width: 8rem;
+
   color: #929292 !important;
   font-size: 10px !important;
 }
 
 .costUsageDivider {
-  border-left: 0.2em solid#F1F3F5; /* 년도와 전기요금 사이의 줄 */
+  border-left: 0.2em solid #f1f3f5;
 }
+
 .plusIcon {
   width: 1.1rem;
   height: 1.1rem;
@@ -72,6 +85,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
   cursor: pointer;
 }
 
@@ -87,21 +101,25 @@
   top: 6rem;
   border-radius: 1em;
   border: 0.1em solid #b6ec94;
-  box-shadow: 0 0.1rem 0.8rem 0 #d7f3c6;
+
   background: #fff;
+  box-shadow: 0 0.1rem 0.8rem 0 #d7f3c6;
+
   z-index: 100;
   padding: 1rem 0;
 }
 
 .dropdownItem {
   padding: 0.8em 1.2em;
-  cursor: pointer;
+
   color: #5e5e5e;
   font-family: Pretendard;
   font-size: 1.2rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
+
+  cursor: pointer;
 }
 
 .dropdownItem:hover {

--- a/src/app/_component/powerinput/PowerTable.tsx
+++ b/src/app/_component/powerinput/PowerTable.tsx
@@ -121,7 +121,9 @@ const PowerTable: React.FC = () => {
           return value !== undefined ? (
             `${value.toLocaleString()}원`
           ) : (
-            <IconPlus className={styles.plusIcon} />
+            <div className={styles.iconWrapper}>
+              <IconPlus className={styles.plusIcon} />
+            </div>
           );
         }
       },
@@ -132,7 +134,9 @@ const PowerTable: React.FC = () => {
           return value !== undefined ? (
             `${value.toLocaleString()}kWh`
           ) : (
-            <IconPlus className={styles.plusIcon} />
+            <div className={styles.iconWrapper}>
+              <IconPlus className={styles.plusIcon} />
+            </div>
           );
         }
       }

--- a/src/app/powerinput/layout.tsx
+++ b/src/app/powerinput/layout.tsx
@@ -1,0 +1,14 @@
+import TopBar from "@/components/TopBar";
+
+export default function Layout({
+  children
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <TopBar text={"내 파워 입력하기"} />
+      {children}
+    </>
+  );
+}

--- a/src/components/bottomNav.module.css
+++ b/src/components/bottomNav.module.css
@@ -1,15 +1,19 @@
 .navContainer {
   background-color: #fff;
-  box-shadow: 0px 0px 15px 0px var(--Main-Color, #d7f3c6);
-  height: 7.4rem;
-  border-radius: 30px 30px 0px 0px;
+  box-shadow: 0 0.1rem 0.8rem 0 #d7f3c6;
+  height: 74px;
+  border-radius: 3em 3em 0 0;
   display: flex;
   justify-content: center;
   align-items: center;
   position: fixed;
   bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  max-width: 375px;
+  width: 100%;
   z-index: 1000;
-  /* max-width: 37.5rem; */
 }
 
 .navBtn {
@@ -24,7 +28,7 @@
 
 .menuName {
   position: relative;
-  top: -1rem;
+  top: -1.5rem;
   width: 2rem;
   font-size: 1rem;
   font-weight: 500;
@@ -46,7 +50,7 @@
   position: relative;
   top: -2.5rem;
   background-color: white;
-  border: #91e26b 1px solid;
+  border: #91e26b 0.1em solid;
   display: flex;
   width: 5.3rem;
   height: 5.3rem;
@@ -58,7 +62,7 @@
 
 .menuHomeActive {
   background-color: #91e26b;
-  box-shadow: 0px 0px 15px 0px #d7f3c6;
+  box-shadow: 0 0 1.5rem 0 #d7f3c6;
 }
 
 .NavIcon {

--- a/src/components/bottomNav.module.css
+++ b/src/components/bottomNav.module.css
@@ -1,7 +1,7 @@
 .navContainer {
   background-color: #fff;
   box-shadow: 0px 0px 15px 0px var(--Main-Color, #d7f3c6);
-  height: 74px;
+  height: 7.4rem;
   border-radius: 30px 30px 0px 0px;
   display: flex;
   justify-content: center;
@@ -9,7 +9,7 @@
   position: fixed;
   bottom: 0;
   z-index: 1000;
-  max-width: 375px;
+  /* max-width: 37.5rem; */
 }
 
 .navBtn {
@@ -26,7 +26,7 @@
   position: relative;
   top: -1rem;
   width: 2rem;
-  font-size: 10px;
+  font-size: 1rem;
   font-weight: 500;
   text-align: center;
   color: gray;
@@ -44,12 +44,12 @@
 
 .menuHome {
   position: relative;
-  top: -1.5rem;
+  top: -2.5rem;
   background-color: white;
   border: #91e26b 1px solid;
   display: flex;
-  width: 3.3rem;
-  height: 3.3rem;
+  width: 5.3rem;
+  height: 5.3rem;
   justify-content: center;
   align-items: center;
   border-radius: 50%;
@@ -62,15 +62,15 @@
 }
 
 .NavIcon {
-  width: 60px;
+  width: 6rem;
 }
 
 .icon {
-  width: 60px;
-  height: 60px;
+  width: 6rem;
+  height: 6rem;
 }
 
 .homeIcon {
-  width: 27px;
-  height: 27px;
+  width: 2.7rem;
+  height: 2.7rem;
 }

--- a/src/components/bottomNav.module.css
+++ b/src/components/bottomNav.module.css
@@ -1,8 +1,4 @@
 .navContainer {
-  background-color: #fff;
-  box-shadow: 0 0.1rem 0.8rem 0 #d7f3c6;
-  height: 74px;
-  border-radius: 3em 3em 0 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -10,19 +6,28 @@
   bottom: 0;
   left: 0;
   right: 0;
+
+  height: 74px;
   margin: 0 auto;
   max-width: 375px;
   width: 100%;
+  border-radius: 3em 3em 0 0;
+
+  background-color: #fff;
+  box-shadow: 0 0.1rem 0.8rem 0 #d7f3c6;
+
   z-index: 1000;
 }
 
 .navBtn {
-  height: 100%;
-  width: 6rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+
+  height: 100%;
+  width: 6rem;
+
   cursor: pointer;
 }
 
@@ -30,6 +35,7 @@
   position: relative;
   top: -1.5rem;
   width: 2rem;
+
   font-size: 1rem;
   font-weight: 500;
   text-align: center;
@@ -41,22 +47,26 @@
 }
 
 .menuHomeContainer {
-  width: 7rem;
   display: flex;
   justify-content: center;
+
+  width: 7rem;
 }
 
 .menuHome {
   position: relative;
   top: -2.5rem;
-  background-color: white;
-  border: #91e26b 0.1em solid;
   display: flex;
-  width: 5.3rem;
-  height: 5.3rem;
   justify-content: center;
   align-items: center;
+
+  width: 5.3rem;
+  height: 5.3rem;
   border-radius: 50%;
+
+  background-color: white;
+  border: #91e26b 0.1em solid;
+
   cursor: pointer;
 }
 

--- a/src/components/bottomNav.tsx
+++ b/src/components/bottomNav.tsx
@@ -13,7 +13,7 @@ import IconClickAppliance from "../../public/icon/nav_appliance_click.svg";
 import IconClickHome from "../../public/icon/nav_home_click.svg";
 import IconClickMy from "../../public/icon/nav_my_click.svg";
 
-import styles from "./BottomNav.module.css";
+import styles from "./bottomNav.module.css";
 
 export default function BottomNav() {
   const [activeButton, setActiveButton] = useState<string>("home");


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
<!-- ex) close #1 -->
#17 

## ✅ 작업 목록
<!-- 이슈 작업한 내용 -->
### 1. px, rem, em 단위 정리
```
em : 레이아웃, 여백 (padding, margin, border-radius)
rem : 일반적인 요소들 
px : 레이아웃 중에서도 고정 사이즈여야 하는 것(상단바, 하단바 등)

```
### 2. 파워 입력 페이지 레이아웃 수정(상단바 추가, 배경 추가)

## 🍰 논의사항
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->
### 1. 파워 메인 페이지의 단위 변경은 다음 작업때 할 예정입니다.

### 2. 플러스 아이콘이 작아 보이는 이유는 실제로 작은게 맞습니다!(1.1rem)
- 1.5rem으로 했을 때 아이콘과 텍스트 크기가 달라 행마다 높이가 달라지는 문제 발생
-> 임시로 아이콘 사이즈를 줄여뒀고, 행 높이 고정하면서 가운데정렬 시키는 방법을 찾아보겠습니다.
## 📷 ETC
<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
<img width="376" alt="스크린샷 2024-10-20 02 46 49" src="https://github.com/user-attachments/assets/18748c2a-13de-4d66-8e53-5cfe7c22cd38">

