### PR TITLE
Feat: 가전 상세페이지 디자인 퍼블리싱

### DIFF
--- a/src/app/_component/appliances/Appliance.tsx
+++ b/src/app/_component/appliances/Appliance.tsx
@@ -1,5 +1,5 @@
 import style from "./Appliance.module.css";
-import { getColorFromGrade } from "@/utils/getColorFromGrade";
+import { getColorFromGrade } from "@/utils/getColorfromGrade";
 import Image from "next/image";
 import airConditioner from "@/../public/img/air-conditioner.png";
 import refrigerator from "@/../public/img/refrigerator.png";

--- a/src/app/_component/appliances/[id]/BottomView.module.css
+++ b/src/app/_component/appliances/[id]/BottomView.module.css
@@ -1,0 +1,8 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  margin-top: 4.2em;
+}

--- a/src/app/_component/appliances/[id]/BottomView.tsx
+++ b/src/app/_component/appliances/[id]/BottomView.tsx
@@ -1,0 +1,9 @@
+import style from "./BottomView.module.css";
+
+export default function BottomView() {
+  return (
+    <div>
+      Bottom
+    </div>
+  )
+}

--- a/src/app/_component/appliances/[id]/BottomView.tsx
+++ b/src/app/_component/appliances/[id]/BottomView.tsx
@@ -1,9 +1,23 @@
 import style from "./BottomView.module.css";
+import ItemRow from "./ItemRow";
 
-export default function BottomView() {
-  return (
-    <div>
-      Bottom
-    </div>
-  )
+interface BottomViewProps {
+  [key: string]: any;
 }
+
+const BottomView = ({ ...applianceDetails }: BottomViewProps) => {
+  const excludedKeys = ["업체명칭", "기자재명칭", "모델명", "제조원", "효율등급"];
+
+  return (
+    <div className={style.container}>
+      {Object.entries(applianceDetails)
+        .filter(([key]) => !excludedKeys.includes(key))
+        .map(
+          ([key, value]) =>
+            value !== null && value !== "NULL" && <ItemRow key={key} label={key} value={value} />
+        )}
+    </div>
+  );
+};
+
+export default BottomView;

--- a/src/app/_component/appliances/[id]/ItemRow.module.css
+++ b/src/app/_component/appliances/[id]/ItemRow.module.css
@@ -1,0 +1,36 @@
+.row {
+  display: flex;
+  align-items: center;
+
+  height: 4rem;
+  margin: 0;
+  width: 31.8rem;
+}
+
+.key {
+  width: 20rem;
+  padding-left: 1em;
+
+  color: #5e5e5e;
+  text-align: left;
+  font-size: 1.4rem;
+
+  font-weight: 400;
+  line-height: normal;
+}
+
+.separator {
+  width: 0.2rem;
+  height: 100%;
+  margin-right: 2em;
+
+  background-color: #f1f3f5;
+}
+
+.value {
+  width: 10.4rem;
+  color: #000;
+  text-align: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+}

--- a/src/app/_component/appliances/[id]/ItemRow.tsx
+++ b/src/app/_component/appliances/[id]/ItemRow.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import style from "./ItemRow.module.css";
+
+interface ItemRowProps {
+  label: string;
+  value: string | number;
+}
+
+const ItemRow = ({ label, value }: ItemRowProps) => {
+  return (
+    <div className={style.row}>
+      <div className={style.key}>{label}</div>
+      <div className={style.separator}></div>
+      <div className={style.value}>{value}</div>
+    </div>
+  );
+};
+
+export default ItemRow;

--- a/src/app/_component/appliances/[id]/ItemRow.tsx
+++ b/src/app/_component/appliances/[id]/ItemRow.tsx
@@ -7,14 +7,12 @@ interface ItemRowProps {
 }
 
 const ItemRow = ({ label, value }: ItemRowProps) => {
-  // 문자열일 경우 첫 번째 숫자만 추출
-  const numericValue = typeof value === "string" ? value.match(/^\d+(\.\d+)?/)?.[0] : value;
-
+    
   return (
     <div className={style.row}>
       <div className={style.key}>{label}</div>
       <div className={style.separator}></div>
-      <div className={style.value}>{numericValue}</div>
+      <div className={style.value}>{value}</div>
     </div>
   );
 };

--- a/src/app/_component/appliances/[id]/ItemRow.tsx
+++ b/src/app/_component/appliances/[id]/ItemRow.tsx
@@ -7,11 +7,14 @@ interface ItemRowProps {
 }
 
 const ItemRow = ({ label, value }: ItemRowProps) => {
+  // 문자열일 경우 첫 번째 숫자만 추출
+  const numericValue = typeof value === "string" ? value.match(/^\d+(\.\d+)?/)?.[0] : value;
+
   return (
     <div className={style.row}>
       <div className={style.key}>{label}</div>
       <div className={style.separator}></div>
-      <div className={style.value}>{value}</div>
+      <div className={style.value}>{numericValue}</div>
     </div>
   );
 };

--- a/src/app/_component/appliances/[id]/TopView.module.css
+++ b/src/app/_component/appliances/[id]/TopView.module.css
@@ -1,0 +1,89 @@
+.TopWrapper {
+  display: flex;
+  align-items: center;
+  gap: 2.7rem;
+}
+
+.Circle {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 10rem;
+  height: 10rem;
+  border-radius: 200%;
+
+  background-color: white;
+  border: 3px solid #83c63f;
+  box-sizing: border-box;
+}
+
+.RightContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+.TextWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.TextContainer {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+}
+.TextBold {
+  color: #000;
+
+  font-size: 1.6rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+}
+.TextRegular {
+  color: #000;
+
+  font-family: Pretendard;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  letter-spacing: 0.014rem;
+}
+.BtnContainer {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.GrayBtn {
+  display: flex;
+  align-items: center;
+  padding: 0 0.8rem;
+  border-radius: 2rem;
+  background: #5e5e5e;
+  height: 2rem;
+
+  color: #fff;
+  text-align: center;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}
+
+.ColorBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 1.6rem;
+  border-radius: 2rem;
+  height: 2rem;
+
+  color: #fff;
+  text-align: center;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}

--- a/src/app/_component/appliances/[id]/TopView.module.css
+++ b/src/app/_component/appliances/[id]/TopView.module.css
@@ -1,7 +1,7 @@
 .TopWrapper {
   display: flex;
   align-items: center;
-  gap: 2.7rem;
+  gap: 2.7em;
 }
 
 .Circle {
@@ -12,60 +12,63 @@
   width: 10rem;
   height: 10rem;
   border-radius: 200%;
+  box-sizing: border-box;
 
   background-color: white;
-  border: 3px solid #83c63f;
-  box-sizing: border-box;
+  border: 0.3em solid #83c63f;
 }
 
 .RightContainer {
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 1.2em;
 }
+
 .TextWrapper {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1em;
 }
+
 .TextContainer {
   display: flex;
   align-items: center;
-  gap: 1.1rem;
+  gap: 1.1em;
 }
-.TextBold {
-  color: #000;
 
+.TextBold {
   font-size: 1.6rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
-}
-.TextRegular {
   color: #000;
+}
 
+.TextRegular {
   font-family: Pretendard;
   font-size: 1.4rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
   letter-spacing: 0.014rem;
+  color: #000;
 }
+
 .BtnContainer {
   display: flex;
-  gap: 0.6rem;
+  gap: 0.6em;
 }
 
 .GrayBtn {
   display: flex;
   align-items: center;
-  padding: 0 0.8rem;
-  border-radius: 2rem;
-  background: #5e5e5e;
-  height: 2rem;
-
-  color: #fff;
+  padding: 0 0.8em;
+  border-radius: 2em;
+  height: 2em;
   text-align: center;
+
+  background: #5e5e5e;
+  color: #fff;
   font-size: 1rem;
   font-style: normal;
   font-weight: 400;
@@ -76,12 +79,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0 1.6rem;
-  border-radius: 2rem;
-  height: 2rem;
+  padding: 0 1.6em;
+  border-radius: 2em;
+  height: 2em;
+  text-align: center;
 
   color: #fff;
-  text-align: center;
   font-size: 1rem;
   font-style: normal;
   font-weight: 400;

--- a/src/app/_component/appliances/[id]/TopView.tsx
+++ b/src/app/_component/appliances/[id]/TopView.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import style from "./TopView.module.css";
-import { ApplianceType } from "@/mock/appliances";
 import { getColorFromGrade } from "@/utils/getColorfromGrade";
 import washingMachine from "@/../public/img/washing-machine.png";
 

--- a/src/app/_component/appliances/[id]/TopView.tsx
+++ b/src/app/_component/appliances/[id]/TopView.tsx
@@ -1,0 +1,64 @@
+import Image from "next/image";
+import style from "./TopView.module.css";
+import { ApplianceType } from "@/mock/appliances";
+import { getColorFromGrade } from "@/utils/getColorfromGrade";
+import washingMachine from "@/../public/img/washing-machine.png";
+
+interface TopViewProps {
+  업체명칭: string;
+  모델명: string;
+  기자재명칭: string;
+  효율등급: string;
+}
+
+const TopView = ({ 업체명칭, 기자재명칭, 모델명, 효율등급 }: TopViewProps) => {
+  const getImage = (type: string) => {
+    switch (type) {
+      case "전기세탁기(일반)":
+        return washingMachine;
+      case "김치냉장고":
+        return washingMachine;
+      default:
+        return washingMachine;
+    }
+  };
+
+  return (
+    <div className={style.TopWrapper}>
+      <div>
+        <div className={style.Circle} style={{ borderColor: getColorFromGrade(Number(효율등급)) }}>
+          <Image
+            src={getImage(기자재명칭)}
+            alt={기자재명칭}
+            width={45}
+            style={{ objectFit: "cover" }}
+            priority={true}
+          />
+        </div>
+      </div>
+      <div className={style.RightContainer}>
+        <div className={style.TextWrapper}>
+          <div className={style.TextContainer}>
+            <span className={style.TextBold}>모델명</span>
+            <span className={style.TextRegular}>{모델명}</span>
+          </div>
+          <div className={style.TextContainer}>
+            <span className={style.TextBold}>업체명</span>
+            <span className={style.TextRegular}>{업체명칭}</span>
+          </div>
+        </div>
+        <div className={style.BtnContainer}>
+          <div className={style.GrayBtn}>{기자재명칭}</div>
+          <div
+            className={style.ColorBtn}
+            style={{ backgroundColor: getColorFromGrade(Number(효율등급)) }}
+          >
+            {효율등급}등급
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TopView;

--- a/src/app/appliances/(with-my-appliances)/[id]/page.module.css
+++ b/src/app/appliances/(with-my-appliances)/[id]/page.module.css
@@ -1,9 +1,16 @@
 .BoxWrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-  
-    width: 100%;
-    background-color: #f8fff3;
-  }
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  background-color: #f8fff3;
+}
+
+.ViewWrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/app/appliances/(with-my-appliances)/[id]/page.module.css
+++ b/src/app/appliances/(with-my-appliances)/[id]/page.module.css
@@ -13,7 +13,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 100%;
   padding: 1rem;
   min-height: 452px;
 }

--- a/src/app/appliances/(with-my-appliances)/[id]/page.module.css
+++ b/src/app/appliances/(with-my-appliances)/[id]/page.module.css
@@ -13,4 +13,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  width: 100%;
+  padding: 1rem;
+  min-height: 452px;
 }

--- a/src/app/appliances/(with-my-appliances)/[id]/page.tsx
+++ b/src/app/appliances/(with-my-appliances)/[id]/page.tsx
@@ -36,23 +36,10 @@ export default function AppliancePage({ params }: { params: { id: string | strin
 
   return (
     <div className={style.BoxWrapper}>
-      <h1>모델명: {applianceDetails.모델명}</h1>
-      <h1>업체명: {applianceDetails.업체명칭}</h1>
-      <h1>{applianceDetails.기자재명칭}</h1>
-      <h1>{applianceDetails.효율등급}등급</h1>
-      <Box>
+      <Box minHeight="452px">
         <div className={style.ViewWrapper}>
-          {/* {Object.entries(applianceDetails).map(
-          ([key, value]) =>
-            value !== null &&
-            value !== "NULL" && (
-              <p key={key}>
-                {key}: {value}
-              </p>
-            )
-        )} */}
           <TopView {...applianceDetails} />
-          <BottomView />
+          <BottomView {...applianceDetails} />
         </div>
       </Box>
     </div>

--- a/src/app/appliances/(with-my-appliances)/[id]/page.tsx
+++ b/src/app/appliances/(with-my-appliances)/[id]/page.tsx
@@ -1,6 +1,8 @@
 import Box from "@/components/Box";
 import { mapApplianceDetails } from "@/utils/renderApplianceDetails";
 import style from "./page.module.css";
+import TopView from "@/app/_component/appliances/[id]/TopView";
+import BottomView from "@/app/_component/appliances/[id]/BottomView";
 
 export default function AppliancePage({ params }: { params: { id: string | string[] } }) {
   // 서버에서 받은 전체 응답 (api 명세서)
@@ -39,7 +41,8 @@ export default function AppliancePage({ params }: { params: { id: string | strin
       <h1>{applianceDetails.기자재명칭}</h1>
       <h1>{applianceDetails.효율등급}등급</h1>
       <Box>
-        {Object.entries(applianceDetails).map(
+        <div className={style.ViewWrapper}>
+          {/* {Object.entries(applianceDetails).map(
           ([key, value]) =>
             value !== null &&
             value !== "NULL" && (
@@ -47,7 +50,10 @@ export default function AppliancePage({ params }: { params: { id: string | strin
                 {key}: {value}
               </p>
             )
-        )}
+        )} */}
+          <TopView {...applianceDetails} />
+          <BottomView />
+        </div>
       </Box>
     </div>
   );

--- a/src/utils/renderApplianceDetails.ts
+++ b/src/utils/renderApplianceDetails.ts
@@ -68,9 +68,9 @@ export function mapApplianceDetails(appliance: ApplianceData, applianceType: str
       break;
     case "김치냉장고":
       uniqueFields = {
-        김치저장실유효내용적: appliance.KIMCHI_CAPA,
-        월산소비전력량: appliance.MONTHLY_CONS_PWR,
-        소비자효율등급지표: appliance.CONSUMER_EFFIC_INDEX
+        김치저장실유효내용적: appliance.KIMCHI_AVAIL_CAPA,
+        월산소비전력량: appliance.MONTH_CONS_PWR,
+        소비자효율등급지표: appliance.R
       };
       break;
     case "전기온풍기":

--- a/src/utils/renderApplianceDetails.ts
+++ b/src/utils/renderApplianceDetails.ts
@@ -17,7 +17,7 @@ export function mapApplianceDetails(appliance: ApplianceData, applianceType: str
     모델명: appliance.모델명,
     구모델명: appliance.구모델명,
     제조원: appliance.제조원,
-    효율등급: appliance.효율등급 || appliance.효율수준 || appliance.효율기준
+    효율등급: appliance.효율등급
   };
 
   // 고유 필드 매핑


### PR DESCRIPTION
## 📝 PR 유형
- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #19 

## ✅ 작업 목록
- 디자인 퍼블리싱

## 🍰 논의사항
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->
1. 단위 제거하기
피그마 디자인에서는 단위 말고 숫자만 렌더링하는데, 고유 필드 응답 값들이 다 일정하지 않아 예외처리가 어려워 일단은 필드 전체값을 렌더링하는 것으로 작업했습니다. (예시: OLDX_MODEL_TERM":"DOE2235D", "HPRO_YN_NM":"국산", "KIMCHI_AVAIL_CAPA":"221.5(ℓ)" 중에서 OLDX_MODEL_TERM처럼 문자열과 숫자가 혼용되어 쓰이는 경우)

첫 숫자만 렌더링 후 뒤에 있는 문자열은 제거(단위만 제거한다는 뜻)하는 방식으로 처음에 작업했으나, 구모델명처럼 숫자가 중간에 섞여 있는 응답 값의 경우 문제가 발생했습니다.

혹시 이 부분 어떻게 해결할지 아이디어 있으시면 주시면 감사하겠습니다...😭

-> 코드리뷰 주시면 3등급의 경우 내부 글씨 색 디자인 대로 변경하는 쪽으로 추후 수정 하겠습니다! 

## 📷 ETC
API 명세 대로 응답받았을 경우 렌더링하는 2가지 예시
<img width="363" alt="스크린샷 2024-10-25 오후 8 28 33" src="https://github.com/user-attachments/assets/69ec0161-0e30-4a33-aa42-b28cd8d9976b">
<img width="363" alt="스크린샷 2024-10-25 오후 8 26 22" src="https://github.com/user-attachments/assets/2a2a7e51-5994-4ff5-ba86-ad9f30402bce">




