### PR TITLE
Fix: eslint export default 배열에서 객체로 전달로 수정

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,12 +3,13 @@ import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
-
-/** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {languageOptions: { globals: globals.browser }},
-  pluginJs.configs.recommended,
+/** @type {import('eslint').Linter.Config} */
+export default {
+  files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"],
+  languageOptions: {
+    globals: globals.browser
+  },
+  ...pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
-  pluginReact.configs.flat.recommended,
-];
+  ...pluginReact.configs.flat.recommended
+};


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #49
에러 상황: react 18, eslint 9 최신 버전을 사용 중인데, 갑자기
```'React' must be in scope when using JSX``` eslint 에러가 나왔습니다.
관련 플러그인을 분명히 적용 중인데, 적용이 되지 않아 발생한 에러입니다.

## ✅ 작업 목록
- ESLint의 설정 파일 객체 형식으로 작성

## 🍰 논의사항
기존 이슈에서는 중복 파일 인식만 해당하는 오류 이슈로 생각했으나, ESLint 설정 파일이 배열을 반환해서 발생한 오류인 것 같습니다. ESLint의 설정 파일은 객체 형식으로 작성해야 합니다. 공식 문서에 따르면, 설정 파일은 extends, plugins, rules와 같은 속성을 포함하는 객체를 반환해야 합니다. 배열 형식으로 설정 파일을 작성하면 ESLint가 이를 올바르게 해석하지 못해 오류가 발생할 수 있어 해당 이슈였던 것 같습니다.

요약: 설정 파일을 작성할 때는 객체 형식으로 구성하는 것이 권장됩니다.

## 📷 ETC
(https://eslint.org/docs/latest/use/getting-started)

