### PR TITLE
Refactor: 예상금액 차트 클릭 구현 및 바텀시트 제작

### DIFF
--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -86,15 +86,38 @@ function ExpectPreChart() {
         return "";
     }
   };
+
+  // 팁멘트 꼬리
+  const [tailPosition, setTailPosition] = useState<number>(120); // 초기 값: 가운데
+  const updateTailPosition = (type: "twoMonth" | "lastMonth" | "currentMonth") => {
+    switch (type) {
+      case "twoMonth":
+        setTailPosition(30);
+        break;
+      case "lastMonth":
+        setTailPosition(120);
+        break;
+      case "currentMonth":
+        setTailPosition(210);
+        break;
+      default:
+        setTailPosition(120);
+    }
+  };
+
   // 클릭 시 실행
   const [preCost, setPreCost] = useState<number | null>(null);
   const [currentCost, setCurrentCost] = useState<number | null>(null);
 
   const [preMonthLabel, setPreMonthLabel] = useState("");
   const [currentMonthLabel, setCurrentMonthLabel] = useState("");
+  const [selectedMonth, setSelectedMonth] = useState<string | null>(null);
+
   const handleChartClick = (type: "twoMonth" | "lastMonth" | "currentMonth") => {
     let pre: number | null;
     let current: number | null;
+
+    updateTailPosition(type);
 
     switch (type) {
       case "twoMonth":
@@ -103,6 +126,8 @@ function ExpectPreChart() {
         setCommentType("general");
         setPreMonthLabel(getDateLabel("threeMonths").monthLabel);
         setCurrentMonthLabel(getDateLabel("twoMonths").monthLabel);
+        setSelectedMonth("twoMonths");
+
         break;
       case "lastMonth":
         pre = chargeData.twoMonthsAgo;
@@ -110,6 +135,8 @@ function ExpectPreChart() {
         setCommentType("general");
         setPreMonthLabel(getDateLabel("twoMonths").monthLabel);
         setCurrentMonthLabel(getDateLabel("last").monthLabel);
+        setSelectedMonth("lastMonth");
+
         break;
       case "currentMonth":
         pre = chargeData.lastMonth;
@@ -117,6 +144,7 @@ function ExpectPreChart() {
         setCommentType("expect");
         setPreMonthLabel(getDateLabel("last").monthLabel);
         setCurrentMonthLabel(getDateLabel("current").monthLabel);
+        setSelectedMonth("currentMonth");
         break;
       default:
         pre = null;
@@ -287,13 +315,25 @@ function ExpectPreChart() {
     }
   };
 
+  const SpeechBalloon: React.FC<{ tailX: number }> = ({ tailX }) => (
+    <svg
+      width="243"
+      height="95"
+      viewBox="0 0 243 95"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect y="12" width="243" height="83" rx="10" fill="#F1F3F5" />
+
+      <path d={`M${tailX} 0 L${tailX + 8.227} 12 H${tailX - 8.227} L${tailX} 0Z`} fill="#F1F3F5" />
+    </svg>
+  );
+
   //   팁멘트 아이콘
   const TipMentIcon = () => {
-    if (differenceType === "noMonths" || differenceType === "noCurrentMonth") {
-      return <TipMentIconSmall style={{ width: "24.3rem", height: "6rem" }} />;
-    }
-    return <TipMentIconBig style={{ width: "24.3rem", height: "9.5rem" }} />;
+    return <SpeechBalloon tailX={tailPosition} />;
   };
+
   return (
     <>
       <div className={styles.chartContainer}>
@@ -332,7 +372,11 @@ function ExpectPreChart() {
               </p>
             </div>
           </div>
-          <p className={styles.monthLabel}>{`${twoMonthsDate.monthLabel}월`}</p>
+          <p
+            className={`${styles.monthLabel} ${selectedMonth === "twoMonths" ? styles.monthLabelClick : ""}`}
+          >
+            {`${twoMonthsDate.monthLabel}월`}
+          </p>{" "}
         </div>
         {/* 전월 */}
         <div className={styles.chartUnit} onClick={() => handleChartClick("lastMonth")}>
@@ -369,7 +413,11 @@ function ExpectPreChart() {
               </p>
             </div>
           </div>
-          <p className={styles.monthLabelClick}>{`${lastMonthDate.monthLabel}월`}</p>
+          <p
+            className={`${styles.monthLabel} ${selectedMonth === "lastMonth" ? styles.monthLabelClick : ""}`}
+          >
+            {`${lastMonthDate.monthLabel}월`}
+          </p>{" "}
         </div>
         {/* 예상요금 */}
         <div className={styles.chartUnit} onClick={() => handleChartClick("currentMonth")}>
@@ -415,7 +463,11 @@ function ExpectPreChart() {
               </p>
             </div>
           </div>
-          <p className={styles.monthLabel}>{`${currentMonthDate.monthLabel}월`}</p>
+          <p
+            className={`${styles.monthLabel} ${selectedMonth === "currentMonth" ? styles.monthLabelClick : ""}`}
+          >
+            {`${currentMonthDate.monthLabel}월`}
+          </p>{" "}
         </div>
       </div>
       <div className={styles.tipContainer}>

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -31,6 +31,7 @@ function ExpectPreChart() {
   });
   const [differenceType, setDifferenceType] = useState<DifferenceType>("noMonths");
   const [isLoading, setIsLoading] = useState(true);
+  const [commentType, setCommentType] = useState<"general" | "expect">("general");
 
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
   const userId = 1;
@@ -99,18 +100,21 @@ function ExpectPreChart() {
       case "twoMonth":
         pre = chargeData.threeMonthsAgo;
         current = chargeData.twoMonthsAgo;
+        setCommentType("general");
         setPreMonthLabel(getDateLabel("threeMonths").monthLabel);
         setCurrentMonthLabel(getDateLabel("twoMonths").monthLabel);
         break;
       case "lastMonth":
         pre = chargeData.twoMonthsAgo;
         current = chargeData.lastMonth;
+        setCommentType("general");
         setPreMonthLabel(getDateLabel("twoMonths").monthLabel);
         setCurrentMonthLabel(getDateLabel("last").monthLabel);
         break;
       case "currentMonth":
         pre = chargeData.lastMonth;
         current = chargeData.expectedCost;
+        setCommentType("expect");
         setPreMonthLabel(getDateLabel("last").monthLabel);
         setCurrentMonthLabel(getDateLabel("current").monthLabel);
         break;
@@ -147,68 +151,142 @@ function ExpectPreChart() {
 
   const difference = calculateDifference();
 
-  const renderComment = () => {
+  const commentTexts = {
+    general: {
+      noMonths: <>파워를 입력해주세요!</>,
+      noPreMonth: (
+        <>
+          <p>
+            {`${currentMonthLabel}월 요금은 `}
+            <span className={styles.costText}>{currentCost?.toLocaleString()}원이에요!</span>
+            <br />
+            전달 파워를 입력하면 더 많은 정보를 보여드릴게요!
+          </p>
+        </>
+      ),
+      noCurrentMonth: <>{`${currentMonthLabel}월 파워를 입력해주세요!`}</>,
+      increase: (
+        <>
+          <p>
+            {`${preMonthLabel}월에 비해 `}
+            <span className={styles.costRed}>{difference?.toLocaleString()}원 증가했어요!</span>
+            <br />
+            조금 더 전기를 아껴보는 건 어떨까요?
+            <br />
+            에너지 백과를 통해 다양한 팁을 살펴보아요!
+          </p>
+        </>
+      ),
+      unchanged: (
+        <>
+          <p>
+            {`${preMonthLabel}월과 `}
+            <span className={styles.costGreen}>같은</span> 전기사용량이네요!
+            <br />
+            조금 더 아껴서 다음 달에는 <br />
+            절약해보는 건 어떨까요?
+            <br /> 에너지 백과를 통해 다양한 팁을 살펴보아요!
+          </p>
+        </>
+      ),
+      decrease: (
+        <>
+          <p>
+            {`${preMonthLabel}월에 비해 `}
+            <span className={styles.costBlue}>{Math.abs(difference!).toLocaleString()}원 </span>
+            감소했어요!
+            <br />
+            아주 잘하고 있군요!
+            <br />
+            앞으로도 그린스파크와 함께 더 나은
+            <br /> 전력소비 해보아요!
+          </p>
+        </>
+      )
+    },
+    expect: {
+      noMonths: <>예상 요금을 입력해주세요!</>,
+      noPreMonth: (
+        <>
+          <p>
+            {" "}
+            예상요금은{" "}
+            <span className={styles.costText}>{currentCost?.toLocaleString()}원이에요!</span>
+            <br />
+            {preMonthLabel}월 파워를 입력하면
+            <br /> 더 정확한 예측을 할 수 있어요!
+          </p>
+        </>
+      ),
+      noCurrentMonth: (
+        <>
+          <p>파워를 입력하면 예상 요금을 알 수 있어요</p>
+        </>
+      ),
+
+      increase: (
+        <>
+          <p>
+            {`${preMonthLabel}월에 비해 `}
+            <span className={styles.costRed}>
+              {difference?.toLocaleString()}원 증가할 것 같군요.
+            </span>
+            <br />
+            조금 더 전기를 아껴보는 건 어떨까요?
+            <br />
+            에너지 백과를 통해 다양한 팁을 살펴보아요!
+          </p>
+        </>
+      ),
+      unchanged: (
+        <>
+          <p>
+            {`${preMonthLabel}월과 전기사용량이 `}
+            <span className={styles.costGreen}>같을</span> 예정이에요!
+            <br />
+            조금 더 아껴서 다음 달에는 <br />
+            절약해보는 건 어떨까요?
+            <br /> 에너지 백과를 통해 다양한 팁을 살펴보아요!
+          </p>
+        </>
+      ),
+      decrease: (
+        <>
+          <p>
+            {`${preMonthLabel}월에 비해 `}
+            <span className={styles.costBlue}>{Math.abs(difference!).toLocaleString()}원 </span>
+            감소할 것 같아요!
+            <br />
+            아주 잘하고 있군요!
+            <br />
+            앞으로도 그린스파크와 함께 더 나은
+            <br /> 전력소비 해보아요!
+          </p>
+        </>
+      )
+    }
+  };
+
+  const generateComment = () => {
+    const texts = commentTexts[commentType];
     switch (differenceType) {
       case "noMonths":
-        return <>파워를 입력해주세요!</>;
+        return texts.noMonths;
       case "noPreMonth":
-        return (
-          <>
-            <p>
-              {`${currentMonthLabel}월 요금은 `}
-              <span className={styles.costText}>{currentCost}원이에요!</span>
-              <br /> 전달 파워를 입력하면 <br />더 많은 정보를 보여드릴게요!
-            </p>
-          </>
-        );
+        return texts.noPreMonth;
       case "noCurrentMonth":
-        return <>{`${currentMonthLabel}월 파워를 입력해주세요!`}</>;
+        return texts.noCurrentMonth;
       case "increase":
-        return (
-          <>
-            <p>
-              {`${preMonthLabel}월에 비해 `}
-              <span className={styles.costRed}>{Math.abs(difference!).toLocaleString()}원 </span>
-              증가했어요!
-              <br />
-              조금 더 전기를 아껴보는 건 어떨까요?
-              <br />
-              에너지 백과를 통해 다양한 팁을 살펴보아요!
-            </p>
-          </>
-        );
-      case "unchanged":
-        return (
-          <>
-            <p>
-              {`${preMonthLabel}월과 `}
-              <span className={styles.costGreen}>같은</span> 전기사용량이네요!
-              <br />
-              조금 더 아껴서 다음 달에는 <br />
-              절약해보는 건 어떨까요?
-              <br /> 에너지 백과를 통해 다양한 팁을 살펴보아요!
-            </p>
-          </>
-        );
+        return texts.increase;
       case "decrease":
-        return (
-          <>
-            <p>
-              {`${preMonthLabel}월에 비해 `}
-              <span className={styles.costBlue}>{Math.abs(difference!).toLocaleString()}원 </span>
-              감소했어요!
-              <br />
-              아주 잘하고 있군요!
-              <br />
-              앞으로도 그린스파크와 함께 더 나은
-              <br /> 전력소비 해보아요!
-            </p>
-          </>
-        );
+        return texts.decrease;
+      case "unchanged":
+        return texts.unchanged; //
       default:
         return <>정보를 입력해주세요!</>;
     }
   };
+
   //   팁멘트 아이콘
   const TipMentIcon = () => {
     if (differenceType === "noMonths" || differenceType === "noCurrentMonth") {
@@ -349,7 +427,7 @@ function ExpectPreChart() {
               : styles.tipMentBig
           }`}
         >
-          {renderComment()}
+          {generateComment()}
         </div>
       </div>
     </>

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -88,6 +88,7 @@ function ExpectPreChart() {
   const currentMonthDate = getDateLabel("current");
   const lastMonthDate = getDateLabel("last");
   const twoMonthsDate = getDateLabel("twoMonths");
+  const threeMonthsDate = getDateLabel("threeMonths");
 
   // 요금에 따라 스타일 설정
   const getChartColorClass = (cost: number | null) => {
@@ -186,9 +187,32 @@ function ExpectPreChart() {
           >
             {chargeData?.twoMonthsAgo?.toLocaleString() ?? "?,???"}원
           </p>
-          <div
-            className={`${styles.chartColor} ${getChartColorClass(chargeData.twoMonthsAgo)}`}
-          ></div>
+          <div className={`${styles.chartColor} ${getChartColorClass(chargeData.lastMonth)}`}>
+            <div className={styles.chartBox}>
+              <p className={styles.chartBoxText}>{`${threeMonthsDate.monthLabel}월 대비`}</p>
+              <p className={styles.costText}>
+                <span
+                  className={
+                    differenceType === "decrease"
+                      ? styles.costBlue
+                      : differenceType === "increase"
+                        ? styles.costRed
+                        : differenceType === "unchanged"
+                          ? styles.costGreen
+                          : styles.costText
+                  }
+                >
+                  {differenceType === "unchanged"
+                    ? "동일"
+                    : differenceType === "increase" || differenceType === "decrease"
+                      ? `${differenceType === "decrease" ? "-" : "+"}${Math.abs(
+                          (chargeData?.lastMonth ?? 0) - (chargeData?.twoMonthsAgo ?? 0)
+                        ).toLocaleString()}원`
+                      : "?,???원"}
+                </span>
+              </p>
+            </div>
+          </div>
           <p className={styles.monthLabel}>{`${twoMonthsDate.monthLabel}월`}</p>
         </div>
         {/* 전월 */}
@@ -224,7 +248,7 @@ function ExpectPreChart() {
               </p>
             </div>
           </div>
-          <p className={styles.lastMonthLabel}>{`${lastMonthDate.monthLabel}월`}</p>
+          <p className={styles.monthLabelClick}>{`${lastMonthDate.monthLabel}월`}</p>
         </div>
         {/* 예상요금 */}
         <div className={styles.chartUnit}>

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -192,7 +192,7 @@ function ExpectPreChart() {
         <>
           <p>
             {`${currentMonthLabel}월 요금은 `}
-            <span className={styles.costText}>{currentCost?.toLocaleString()}원이에요!</span>
+            <span className={styles.costText}>{currentCost?.toLocaleString()}원</span>이에요!
             <br />
             전달 파워를 입력하면 <br />더 많은 정보를 보여드릴게요!
           </p>
@@ -203,7 +203,7 @@ function ExpectPreChart() {
         <>
           <p>
             {`${preMonthLabel}월에 비해 `}
-            <span className={styles.costRed}>{difference?.toLocaleString()}원 증가했어요!</span>
+            <span className={styles.costRed}>{difference?.toLocaleString()}원 </span>증가했어요!
             <br />
             조금 더 전기를 아껴보는 건 어떨까요?
             <br />
@@ -244,8 +244,8 @@ function ExpectPreChart() {
         <>
           <p>
             {" "}
-            예상요금은{" "}
-            <span className={styles.costText}>{currentCost?.toLocaleString()}원이에요!</span>
+            예상요금은 <span className={styles.costText}>{currentCost?.toLocaleString()}원</span>
+            이에요!
             <br />
             {preMonthLabel}월 파워를 입력하면
             <br /> 더 정확한 예측을 할 수 있어요!
@@ -262,9 +262,8 @@ function ExpectPreChart() {
         <>
           <p>
             {`${preMonthLabel}월에 비해 `}
-            <span className={styles.costRed}>
-              {difference?.toLocaleString()}원 증가할 것 같군요.
-            </span>
+            <span className={styles.costRed}>{difference?.toLocaleString()}원 </span>증가할 것
+            같군요.
             <br />
             조금 더 전기를 아껴보는 건 어떨까요?
             <br />

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -61,6 +61,12 @@ function ExpectPreChart() {
 
     fetchCostData();
   }, [API_URL, userId]);
+  // 데이터 로드 후 실행되도록(팁 멘트 디폴트)
+  useEffect(() => {
+    if (!isLoading && chargeData.lastMonth !== null) {
+      handleChartClick("lastMonth");
+    }
+  }, [isLoading, chargeData]);
 
   const determineDifferenceType = (pre: number | null, current: number | null): DifferenceType => {
     if (pre === null && current === null) return "noMonths";
@@ -188,7 +194,7 @@ function ExpectPreChart() {
             {`${currentMonthLabel}월 요금은 `}
             <span className={styles.costText}>{currentCost?.toLocaleString()}원이에요!</span>
             <br />
-            전달 파워를 입력하면 더 많은 정보를 보여드릴게요!
+            전달 파워를 입력하면 <br />더 많은 정보를 보여드릴게요!
           </p>
         </>
       ),

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -150,11 +150,19 @@ function ExpectPreChart() {
   const renderComment = () => {
     switch (differenceType) {
       case "noMonths":
-        return <>정보를 입력해주세요!</>;
+        return <>파워를 입력해주세요!</>;
       case "noPreMonth":
-        return <>{`${preMonthLabel}월 전기 요금을 입력해주세요!`}</>;
+        return (
+          <>
+            <p>
+              {`${currentMonthLabel}월 요금은 `}
+              <span className={styles.costText}>{currentCost}원이에요!</span>
+              <br /> 전달 파워를 입력하면 <br />더 많은 정보를 보여드릴게요!
+            </p>
+          </>
+        );
       case "noCurrentMonth":
-        return <>{`${currentMonthLabel}월 전기 요금을 입력해주세요!`}</>;
+        return <>{`${currentMonthLabel}월 파워를 입력해주세요!`}</>;
       case "increase":
         return (
           <>
@@ -203,11 +211,7 @@ function ExpectPreChart() {
   };
   //   팁멘트 아이콘
   const TipMentIcon = () => {
-    if (
-      differenceType === "noMonths" ||
-      differenceType === "noPreMonth" ||
-      differenceType === "noCurrentMonth"
-    ) {
+    if (differenceType === "noMonths" || differenceType === "noCurrentMonth") {
       return <TipMentIconSmall style={{ width: "24.3rem", height: "6rem" }} />;
     }
     return <TipMentIconBig style={{ width: "24.3rem", height: "9.5rem" }} />;
@@ -340,9 +344,7 @@ function ExpectPreChart() {
         <TipMentIcon />
         <div
           className={`${styles.tipMent} ${
-            differenceType === "noMonths" ||
-            differenceType === "noCurrentMonth" ||
-            differenceType === "noPreMonth"
+            differenceType === "noMonths" || differenceType === "noCurrentMonth"
               ? styles.tipMentSmall
               : styles.tipMentBig
           }`}

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -193,22 +193,24 @@ function ExpectPreChart() {
               <p className={styles.costText}>
                 <span
                   className={
-                    differenceType === "decrease"
-                      ? styles.costBlue
-                      : differenceType === "increase"
-                        ? styles.costRed
-                        : differenceType === "unchanged"
-                          ? styles.costGreen
-                          : styles.costText
+                    chargeData?.threeMonthsAgo &&
+                    chargeData.twoMonthsAgo &&
+                    chargeData.twoMonthsAgo > chargeData.threeMonthsAgo // 모두 존재, 증가
+                      ? styles.costRed
+                      : chargeData?.threeMonthsAgo &&
+                          chargeData.twoMonthsAgo &&
+                          chargeData.twoMonthsAgo < chargeData.threeMonthsAgo // 모두 존재, 감소
+                        ? styles.costBlue
+                        : styles.costText // 기본
                   }
                 >
-                  {differenceType === "unchanged"
-                    ? "동일"
-                    : differenceType === "increase" || differenceType === "decrease"
-                      ? `${differenceType === "decrease" ? "-" : "+"}${Math.abs(
-                          (chargeData?.lastMonth ?? 0) - (chargeData?.twoMonthsAgo ?? 0)
+                  {chargeData?.threeMonthsAgo && chargeData.twoMonthsAgo
+                    ? chargeData.expectedCost === chargeData.threeMonthsAgo
+                      ? "동일"
+                      : `${chargeData.twoMonthsAgo > chargeData.threeMonthsAgo ? "+" : "-"}${Math.abs(
+                          chargeData.twoMonthsAgo - chargeData.threeMonthsAgo
                         ).toLocaleString()}원`
-                      : "?,???원"}
+                    : "?,???원"}
                 </span>
               </p>
             </div>
@@ -228,22 +230,24 @@ function ExpectPreChart() {
               <p className={styles.costText}>
                 <span
                   className={
-                    differenceType === "decrease"
-                      ? styles.costBlue
-                      : differenceType === "increase"
-                        ? styles.costRed
-                        : differenceType === "unchanged"
-                          ? styles.costGreen
-                          : styles.costText
+                    chargeData?.twoMonthsAgo &&
+                    chargeData.lastMonth &&
+                    chargeData.lastMonth > chargeData.twoMonthsAgo // 모두 존재, 증가
+                      ? styles.costRed
+                      : chargeData?.twoMonthsAgo &&
+                          chargeData.lastMonth &&
+                          chargeData.lastMonth < chargeData.twoMonthsAgo // 모두 존재, 감소
+                        ? styles.costBlue
+                        : styles.costText // 기본
                   }
                 >
-                  {differenceType === "unchanged"
-                    ? "동일"
-                    : differenceType === "increase" || differenceType === "decrease"
-                      ? `${differenceType === "decrease" ? "-" : "+"}${Math.abs(
-                          (chargeData?.lastMonth ?? 0) - (chargeData?.twoMonthsAgo ?? 0)
+                  {chargeData?.twoMonthsAgo && chargeData.lastMonth
+                    ? chargeData.expectedCost === chargeData.twoMonthsAgo
+                      ? "동일"
+                      : `${chargeData.lastMonth > chargeData.twoMonthsAgo ? "+" : "-"}${Math.abs(
+                          chargeData.lastMonth - chargeData.twoMonthsAgo
                         ).toLocaleString()}원`
-                      : "?,???원"}
+                    : "?,???원"}
                 </span>
               </p>
             </div>

--- a/src/app/_component/power/expectPreCost.module.css
+++ b/src/app/_component/power/expectPreCost.module.css
@@ -71,6 +71,7 @@
   flex-direction: column;
   align-items: center;
   width: 10rem;
+  cursor: pointer;
 }
 
 .chartColor {

--- a/src/app/_component/power/expectPreCost.module.css
+++ b/src/app/_component/power/expectPreCost.module.css
@@ -117,7 +117,7 @@
   height: 1.9rem;
 }
 
-.lastMonthLabel {
+.monthLabelClick {
   color: #ffffff;
 
   display: flex;

--- a/src/app/_component/powerinput/InputBottomSheet.module.css
+++ b/src/app/_component/powerinput/InputBottomSheet.module.css
@@ -1,3 +1,4 @@
+/* 바텀시트 공통 스타일 */
 .overlay {
   position: fixed;
   bottom: 0;
@@ -45,17 +46,38 @@
   text-align: center;
 }
 
+.sheetTitle {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+/* 버튼 관련*/
 .btnContainer {
   display: flex;
   flex-direction: column;
 
   gap: 0.6rem;
   margin-top: 2rem;
-}
-
-.sheetTitle {
-  font-size: 2rem;
-  font-weight: 600;
 }
 
 .confirmBtn,
@@ -78,24 +100,4 @@
 
 .reenterBtn {
   background-color: #19e407;
-}
-
-@keyframes slideUp {
-  from {
-    transform: translateY(100%);
-  }
-
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
 }

--- a/src/app/_component/powerinput/InputBottomSheet.module.css
+++ b/src/app/_component/powerinput/InputBottomSheet.module.css
@@ -20,7 +20,7 @@
   flex-direction: column;
   align-items: center;
 
-  width: 34.6rem;
+  width: 32rem;
   height: 18rem;
   border-radius: 3.2rem 3.2rem 0 0;
 

--- a/src/app/_component/powerinput/InputBottomSheet.module.css
+++ b/src/app/_component/powerinput/InputBottomSheet.module.css
@@ -1,0 +1,101 @@
+.overlay {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  width: 100%;
+  height: 100%;
+
+  background-color: rgba(0, 0, 0, 0.5);
+
+  z-index: 2000;
+  transition: background-color 0.3s ease-in-out;
+}
+
+.bottomSheet {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  width: 34.6rem;
+  height: 18rem;
+  border-radius: 3.2rem 3.2rem 0 0;
+
+  background-color: white;
+  padding: 2rem;
+
+  transition: transform 0.2s ease-out;
+}
+
+.bottomBar {
+  width: 8rem;
+  height: 1rem;
+  border-radius: 1rem;
+  margin: 0 auto 1.5rem;
+
+  background-color: #d7f3c6;
+
+  cursor: pointer;
+}
+
+.sheetContent {
+  text-align: center;
+}
+
+.btnContainer {
+  display: flex;
+  flex-direction: column;
+
+  gap: 0.6rem;
+  margin-top: 2rem;
+}
+
+.sheetTitle {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.confirmBtn,
+.reenterBtn {
+  width: 27.7rem;
+  height: 3.8rem;
+  border: none;
+  border-radius: 1.5rem;
+
+  color: white;
+  font-size: 1.6rem;
+  font-weight: 600;
+
+  cursor: pointer;
+}
+
+.confirmBtn {
+  background-color: #c4c4c4;
+}
+
+.reenterBtn {
+  background-color: #19e407;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}

--- a/src/app/_component/powerinput/InputBottomSheet.tsx
+++ b/src/app/_component/powerinput/InputBottomSheet.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import styles from "./InputBottomSheet.module.css";
+
+type InputBottomSheetProps = {
+  onClose: () => void;
+  onConfirmSave: () => void;
+  onReEnter: () => void;
+};
+
+const InputBottomSheet: React.FC<InputBottomSheetProps> = ({
+  onClose,
+  onConfirmSave,
+  onReEnter
+}) => {
+  const [startY, setStartY] = useState<number>(0);
+  const [currentY, setCurrentY] = useState<number>(0);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setStartY(e.touches[0].clientY);
+    setIsDragging(true);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging) return;
+    const deltaY = e.touches[0].clientY - startY; // 이동 거리 계산
+    if (deltaY > 0) setCurrentY(deltaY); //아래로 이동 (양수 값만 적용)
+  };
+
+  const handleTouchEnd = () => {
+    setIsDragging(false);
+    if (currentY > 100) {
+      // 100px 이상 이동 시 바텀시트 닫기
+
+      onClose();
+    } else {
+      setCurrentY(0);
+    }
+  };
+
+  return (
+    <div className={styles.overlay}>
+      <div
+        className={styles.bottomSheet}
+        style={{ transform: `translateY(${currentY}px)` }} // 이동 거리 적용
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        <div className={styles.bottomBar}></div>
+        <div className={styles.sheetContent}>
+          <p className={styles.sheetTitle}>
+            지난 달과 차이가 커요! <br />
+            정확히 입력했나요?
+          </p>
+          <div className={styles.btnContainer}>
+            <button className={styles.confirmBtn} onClick={onConfirmSave}>
+              이대로 입력하기
+            </button>
+            <button className={styles.reenterBtn} onClick={onReEnter}>
+              다시 입력하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InputBottomSheet;

--- a/src/app/_component/powerinput/PowerPopup.tsx
+++ b/src/app/_component/powerinput/PowerPopup.tsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import styles from "./PowerPopup.module.css";
 import Toast from "@/components/Toast";
 import IconClose from "@/../public/icon/popup_close.svg";
+import InputBottomSheet from "./InputBottomSheet";
 
 type PowerPopupProps = {
   userId: number;
@@ -21,14 +22,14 @@ const PowerPopup: React.FC<PowerPopupProps> = ({
   month,
   type,
   value = 0,
-  recentValue = 0, // 최근 값 초기화
+  recentValue = 0,
   onClose,
   onSave
 }) => {
   const [inputValue, setInputValue] = useState<string>(value ? value.toString() : "");
   const [toastMessage, setToastMessage] = useState<string>("");
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
-  const [numericInputValue, setNumericInputValue] = useState<number | null>(null); // 숫자 변환된 입력값
+  const [numericInputValue, setNumericInputValue] = useState<number | null>(null);
 
   const typeName = type === "cost" ? "전기요금" : "전력사용량";
   const unit = type === "cost" ? "원" : "kWh";
@@ -37,7 +38,6 @@ const PowerPopup: React.FC<PowerPopupProps> = ({
     ? `${styles.submitBtn} ${styles.submitBtnGreen}`
     : styles.submitBtn;
 
-  // 숫자 유효성 검사
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     if (value && !/^\d+$/.test(value)) {
@@ -54,9 +54,8 @@ const PowerPopup: React.FC<PowerPopupProps> = ({
     }
 
     const numericValue = Number(inputValue);
-    setNumericInputValue(numericValue); // 입력값 저장
+    setNumericInputValue(numericValue);
 
-    // 최근 값이 0이 아니고, 3배 초과인지
     if (recentValue > 0 && numericValue > recentValue * 3) {
       setShowConfirmation(true);
     } else {
@@ -96,7 +95,7 @@ const PowerPopup: React.FC<PowerPopupProps> = ({
 
   const handleReEnter = () => {
     setShowConfirmation(false);
-    setInputValue(numericInputValue?.toString() || ""); // 기존 입력값으로 되돌리기
+    setInputValue(numericInputValue?.toString() || "");
   };
 
   useEffect(() => {
@@ -131,26 +130,11 @@ const PowerPopup: React.FC<PowerPopupProps> = ({
       </div>
 
       {showConfirmation && (
-        <div className={styles.overlay}>
-          <div className={styles.popup}>
-            <div className={styles.popupBox}>
-              <IconClose className={styles.iconClose} onClick={onClose} />
-
-              <p className={styles.popupTitle}>
-                지난 달과 차이가 커요! <br />
-                정확히 입력했나요?
-              </p>
-              <div className={styles.confirmationBtnContainer}>
-                <button className={styles.confirmBtn} onClick={handleConfirmSave}>
-                  이대로 입력하기
-                </button>
-                <button className={styles.reenterBtn} onClick={handleReEnter}>
-                  다시 입력하기
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <InputBottomSheet
+          onClose={() => setShowConfirmation(false)}
+          onConfirmSave={handleConfirmSave}
+          onReEnter={handleReEnter}
+        />
       )}
     </>
   );

--- a/src/utils/getDateLabels.ts
+++ b/src/utils/getDateLabels.ts
@@ -4,7 +4,7 @@ export interface GetDateLabel {
   dateLabel: Date;
 }
 
-export function getDateLabel(type: "current" | "last" | "twoMonths"): GetDateLabel {
+export function getDateLabel(type: "current" | "last" | "twoMonths" | "threeMonths"): GetDateLabel {
   const now = new Date();
   let monthLabel = "";
   let yearLabel = "";
@@ -19,6 +19,12 @@ export function getDateLabel(type: "current" | "last" | "twoMonths"): GetDateLab
 
     case "twoMonths":
       dateLabel = new Date(now.getFullYear(), now.getMonth() - 2, 1);
+      yearLabel = dateLabel.getFullYear().toString();
+      monthLabel = (dateLabel.getMonth() + 1).toString();
+      break;
+
+    case "threeMonths":
+      dateLabel = new Date(now.getFullYear(), now.getMonth() - 3, 1);
       yearLabel = dateLabel.getFullYear().toString();
       monthLabel = (dateLabel.getMonth() + 1).toString();
       break;


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
<!-- ex) close #1 -->
#79 
## ✅ 작업 목록
<!-- 이슈 작업한 내용 -->
### 1. 지난달, 예상금액 차트 클릭 구현
### 2. 파워 입력 바텀시트 제작
- 따로 컴포넌트로 만들지는 않았지만 ```InputBottomSheet.tsx```와 ```InputBottomSheet.module.css``` 파일 보면 쉽게 사용 가능합니다! 추후 컴포넌트화 고려해보겠습니다.
-> ```InputBottomSheet.module.css``` : 공통스타일과 버튼 스타일 분리해뒀습니다!

## 🍰 논의사항
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->
### 1. ```ExpectPreChart.tsx``` 컴포넌트 분리 계획
파일의 코드가 너무 복잡하고 길어서 컴포넌트 분리가 필요합니다.. 추후 가독성을 위해 컴포넌트 분리하겠습니다!
특히 상태관리 너무 복잡ㅜ

### 2. 예상금액 말풍선 svg
svg 파일을 컴포넌트로 가져와서 사용했었는데 말풍선 꼬리만 이동시키는 것이 힘들어서 svg 링크를 가져와서 그대로 사용했습니다. 멘트에 따라 height도 바뀌도록 수정해야 합니다. 현재 타입과 상태가 복잡해서 추후 코드 정리 후 추가하겠습니다! 
## 📷 ETC
<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->

https://github.com/user-attachments/assets/57156359-9b0d-40dd-8d01-c92cd0495d32

https://github.com/user-attachments/assets/63e99d94-8e59-4cd7-b2e5-e3f6cf6b8196



