### PR TITLE
Feat: 구글 소셜 로그인, 토큰 갱신

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   compiler: {
     styledComponents: true
   },

--- a/src/app/(common-layout)/appliances/[id]/page.tsx
+++ b/src/app/(common-layout)/appliances/[id]/page.tsx
@@ -10,6 +10,7 @@ import TopView from "@/app/_component/appliances/[id]/TopView";
 import BottomView from "@/app/_component/appliances/[id]/BottomView";
 import LoadingDots from "@/components/LoadingDots";
 import DeleteBtn from "@/app/_component/appliances/[id]/DeleteBtn";
+import { apiWrapper } from "@/utils/api";
 
 export default function AppliancePage({ params }: { params: { id: string | string[] } }) {
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -19,22 +20,28 @@ export default function AppliancePage({ params }: { params: { id: string | strin
   useEffect(() => {
     const fetchApplianceData = async () => {
       try {
-        const response = await axios.get(`${API_URL}/appliances/detail/${params.id}`);
+        const response = await apiWrapper(
+          () =>
+            axios.get(`${API_URL}/appliances/detail/${params.id}`, {
+              withCredentials: true
+            }),
+          API_URL
+        );
 
         if (response.data.success) {
           const parsedData = JSON.parse(response.data.data);
           const decodedData = decodeHtmlEntities(parsedData);
           const items = decodedData.items;
 
-          const applianceType = items[0].MACH_TERM || "Unknown";
+          const applianceType = items[0]?.MACH_TERM || "Unknown";
 
           const transformedItem = {
-            업체명칭: items[0].ENTE_TERM,
-            기자재명칭: items[0].MACH_TERM,
-            모델명: items[0].MODEL_TERM,
-            구모델명: items[0].OLDX_MODEL_TERM,
-            제조원: items[0].MANUFAC_MAN_TERM,
-            효율등급: items[0].GRADE,
+            업체명칭: items[0]?.ENTE_TERM,
+            기자재명칭: items[0]?.MACH_TERM,
+            모델명: items[0]?.MODEL_TERM,
+            구모델명: items[0]?.OLDX_MODEL_TERM,
+            제조원: items[0]?.MANUFAC_MAN_TERM,
+            효율등급: items[0]?.GRADE,
             ...items[0]
           };
 

--- a/src/app/(common-layout)/main/page.tsx
+++ b/src/app/(common-layout)/main/page.tsx
@@ -1,21 +1,49 @@
 "use client";
 
-import React from "react";
-import HomeQuiz from "../../_component/home/HomeQuiz";
-import HomeEncyclopedia from "../../_component/home/HomeEncyclopedia";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
 import AttendanceCoin from "../../_component/home/AttendanceCoin";
 import HomePower from "../../_component/home/HomePower";
 import HomeAppliances from "../../_component/home/HomeAppliances";
+import HomeQuiz from "../../_component/home/HomeQuiz";
+import HomeEncyclopedia from "../../_component/home/HomeEncyclopedia";
 
 export default function Page() {
+  const [tokenRenewed, setTokenRenewed] = useState(false);
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+  useEffect(() => {
+    const renewToken = async () => {
+      try {
+        const response = await axios.post(`${API_URL}/reissue`, {}, { withCredentials: true });
+        if (response.data.success) {
+          console.log("토큰 갱신 성공");
+          setTokenRenewed(true);
+        } else {
+          console.error("토큰 갱신 실패:", response.data.message);
+        }
+      } catch (error) {
+        console.error("토큰 갱신 중 오류 발생:", error);
+      }
+    };
+
+    renewToken();
+  }, [API_URL]);
+
   return (
     <div style={{ height: "100vh" }}>
       <div style={{ paddingBottom: "10rem" }}>
-        <AttendanceCoin />
-        <HomePower />
-        <HomeAppliances />
-        <HomeQuiz />
-        <HomeEncyclopedia />
+        {tokenRenewed ? (
+          <>
+            <AttendanceCoin />
+            <HomePower />
+            <HomeAppliances />
+            <HomeQuiz />
+            <HomeEncyclopedia />
+          </>
+        ) : (
+          <p>토큰 갱신 중...</p>
+        )}
       </div>
     </div>
   );

--- a/src/app/(common-layout)/main/page.tsx
+++ b/src/app/(common-layout)/main/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import React from "react";
-import HomeQuiz from "../_component/home/HomeQuiz";
-import HomeEncyclopedia from "../_component/home/HomeEncyclopedia";
-import AttendanceCoin from "../_component/home/AttendanceCoin";
-import HomePower from "../_component/home/HomePower";
-import HomeAppliances from "../_component/home/HomeAppliances";
+import HomeQuiz from "../../_component/home/HomeQuiz";
+import HomeEncyclopedia from "../../_component/home/HomeEncyclopedia";
+import AttendanceCoin from "../../_component/home/AttendanceCoin";
+import HomePower from "../../_component/home/HomePower";
+import HomeAppliances from "../../_component/home/HomeAppliances";
 
 export default function Page() {
   return (

--- a/src/app/(common-layout)/power/page.tsx
+++ b/src/app/(common-layout)/power/page.tsx
@@ -1,16 +1,45 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { apiWrapper } from "@/utils/api";
 
 import PowerInput from "../../_component/power/PowerInput";
 import ExpectPreCost from "../../_component/power/ExpectPreCost";
 import GraphCharge from "../../_component/power/GraphCharge";
 
 export default function Power() {
+  const [tokenRenewed, setTokenRenewed] = useState(false);
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+  useEffect(() => {
+    const renewToken = async () => {
+      try {
+        const response = await axios.post(`${API_URL}/reissue`, {}, { withCredentials: true });
+        if (response.data.success) {
+          console.log("토큰 갱신 성공");
+          setTokenRenewed(true);
+        } else {
+          console.error("토큰 갱신 실패:", response.data.message);
+        }
+      } catch (error) {
+        console.error("토큰 갱신 중 오류 발생:", error);
+      }
+    };
+
+    renewToken();
+  }, [API_URL]);
+
   return (
     <div style={{ height: "100vh", paddingBottom: "10rem", marginTop: "4rem" }}>
-      <GraphCharge />
-      <PowerInput />
-      <ExpectPreCost />
+      {tokenRenewed ? (
+        <>
+          <GraphCharge />
+          <PowerInput />
+          <ExpectPreCost />
+        </>
+      ) : (
+        <p>토큰 갱신 중...</p>
+      )}
     </div>
   );
 }

--- a/src/app/LoginPage.module.css
+++ b/src/app/LoginPage.module.css
@@ -57,33 +57,3 @@
   font-weight: 600;
   line-height: normal;
 }
-
-.loginBtn {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 1rem;
-
-  width: 20rem;
-  height: 4rem;
-  border-radius: 0.5em;
-
-  background-color: white;
-
-  border: none;
-  cursor: pointer;
-}
-
-.googleIcon {
-  width: 1.8rem;
-  height: 1.8rem;
-}
-
-.googleMent {
-  color: #4a4a4a;
-  text-align: center;
-  font-size: 1.4rem;
-  font-style: normal;
-  font-weight: 500;
-  line-height: normal;
-}

--- a/src/app/_component/appliances/ClientComponent.tsx
+++ b/src/app/_component/appliances/ClientComponent.tsx
@@ -12,6 +12,7 @@ import ApplianceList from "../../_component/appliances/ApplianceList";
 import AddButton from "../../_component/appliances/AddButton";
 import LoadingDots from "@/components/LoadingDots";
 import { getDisplayName } from "@/utils/getDisplayName";
+import { apiWrapper } from "@/utils/api";
 
 interface ApplianceItem {
   id: number;
@@ -33,8 +34,6 @@ const applianceOptions = [
   "전기냉장고",
   "전기냉난방기"
 ];
-
-const userId = 1;
 
 export default function ClientComponent() {
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -134,12 +133,20 @@ export default function ClientComponent() {
         originalApplianceName === "공기청정기" ? "공기청정기 (~24.12.31)" : originalApplianceName;
 
       try {
-        const response = await axios.post(`${API_URL}/appliances/${userId}`, {
-          modelTerm: selectedModel.모델명,
-          grade: selectedModel.효율등급,
-          matchTerm: apiApplianceName,
-          manufacturer: selectedModel.업체명
-        });
+        const response = await apiWrapper(
+          () =>
+            axios.post(
+              `${API_URL}/appliances`,
+              {
+                modelTerm: selectedModel.모델명,
+                grade: selectedModel.효율등급,
+                matchTerm: apiApplianceName,
+                manufacturer: selectedModel.업체명
+              },
+              { withCredentials: true }
+            ),
+          API_URL
+        );
 
         if (response.status === 200 && response.data.success) {
           if (response.data.message === "이미 존재하는 가전제품입니다.") {

--- a/src/app/_component/appliances/MyAppliances.tsx
+++ b/src/app/_component/appliances/MyAppliances.tsx
@@ -9,7 +9,6 @@ import style from "./MyAppliances.module.css";
 import GradeLabel from "./GradeLabel";
 import { useEffect, useState } from "react";
 import LoadingDots from "@/components/LoadingDots";
-import { useRouter } from "next/navigation";
 import { apiWrapper } from "@/utils/api";
 
 interface ApplianceData {
@@ -23,7 +22,6 @@ export default function MyAppliances() {
   const [data, setData] = useState<ApplianceData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const router = useRouter();
 
   const fetchAppliances = async (): Promise<ApplianceData[]> => {
     return apiWrapper(async () => {

--- a/src/app/_component/appliances/[id]/DeleteBtn.tsx
+++ b/src/app/_component/appliances/[id]/DeleteBtn.tsx
@@ -2,6 +2,7 @@
 import axios from "axios";
 import style from "./DeleteBtn.module.css";
 import { useRouter } from "next/navigation";
+import { apiWrapper } from "@/utils/api";
 
 interface DeleteBtnProps {
   applianceId: string | string[];
@@ -14,12 +15,17 @@ const DeleteBtn = ({ applianceId }: DeleteBtnProps) => {
 
   const onDelete = async () => {
     try {
-      const res = await axios.post(`${API_URL}/appliances/delete/${userId}/${applianceId}`);
+      const res = await apiWrapper(
+        () =>
+          axios.post(`${API_URL}/appliances/delete/${applianceId}`, {}, { withCredentials: true }),
+        API_URL
+      );
 
       if (res.status === 200) {
         router.push("/list");
       } else {
         console.error("삭제 실패:", res.data);
+        alert("삭제에 실패했습니다.");
       }
     } catch (error) {
       console.error("삭제 중 오류 발생:", error);

--- a/src/app/_component/home/HomeAppliances.tsx
+++ b/src/app/_component/home/HomeAppliances.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import Appliance from "../appliances/Appliance";
 import GradeLabel from "../appliances/GradeLabel";
 import IconPlus from "@/../public/icon/home_plus.svg";
+
 interface ApplianceData {
   applianceId: number;
   grade: string;
@@ -17,12 +18,14 @@ interface ApplianceData {
 export default function HomeAppliances() {
   const [data, setData] = useState<ApplianceData[]>([]);
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const userId = 1;
 
   useEffect(() => {
     const fetchCostData = async () => {
       try {
-        const response = await axios.get(`${API_URL}/appliances/preview/${userId}`);
+        const response = await axios.get(`${API_URL}/appliances/preview`, {
+          withCredentials: true
+        });
+
         if (response.data.success) {
           setData(response.data.data);
         } else {
@@ -34,7 +37,7 @@ export default function HomeAppliances() {
     };
 
     fetchCostData();
-  }, [API_URL, userId]);
+  }, [API_URL]);
 
   return (
     <>

--- a/src/app/_component/home/HomePower.tsx
+++ b/src/app/_component/home/HomePower.tsx
@@ -35,7 +35,7 @@ export default function HomePower() {
   useEffect(() => {
     const fetchCostData = async () => {
       try {
-        const response = await axios.get(`${API_URL}/power/expect/${userId}`);
+        const response = await axios.get(`${API_URL}/power/expect`, { withCredentials: true });
 
         if (response.data.success) {
           const data = response.data.data;

--- a/src/app/_component/login/LoginBtn.module.css
+++ b/src/app/_component/login/LoginBtn.module.css
@@ -1,0 +1,29 @@
+.loginBtn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+
+  width: 20rem;
+  height: 4rem;
+  border-radius: 0.5em;
+
+  background-color: white;
+
+  border: none;
+  cursor: pointer;
+}
+
+.googleIcon {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+
+.googleMent {
+  color: #4a4a4a;
+  text-align: center;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}

--- a/src/app/_component/login/LoginBtn.tsx
+++ b/src/app/_component/login/LoginBtn.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import styles from "./LoginBtn.module.css";
+import IconGoogle from "@/../public/icon/login_google.svg";
+
+export default function LoginBtn() {
+  return (
+    <div>
+      <button type="button" className={styles.loginBtn}>
+        <IconGoogle className={styles.googleIcon} />
+        <p className={styles.googleMent}>Google 계정으로 로그인</p>
+      </button>
+    </div>
+  );
+}

--- a/src/app/_component/login/LoginBtn.tsx
+++ b/src/app/_component/login/LoginBtn.tsx
@@ -4,9 +4,15 @@ import styles from "./LoginBtn.module.css";
 import IconGoogle from "@/../public/icon/login_google.svg";
 
 export default function LoginBtn() {
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const GOOGLE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+  const GOOGLE_REDIRECT_URI = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI;
+  const onGoogleLogin = async () => {
+    window.location.href = `${API_URL}/login`;
+  };
   return (
     <div>
-      <button type="button" className={styles.loginBtn}>
+      <button type="button" className={styles.loginBtn} onClick={onGoogleLogin}>
         <IconGoogle className={styles.googleIcon} />
         <p className={styles.googleMent}>Google 계정으로 로그인</p>
       </button>

--- a/src/app/_component/power/AICharge.tsx
+++ b/src/app/_component/power/AICharge.tsx
@@ -18,12 +18,13 @@ export default function AICharge() {
   const [differenceType, setDifferenceType] = useState<DifferenceType>("noLastMonth");
 
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const userId = 1;
 
   useEffect(() => {
     const fetchCostData = async () => {
       try {
-        const response = await axios.get(`${API_URL}/power/expect/${userId}`);
+        const response = await axios.get(`${API_URL}/power/expect`, {
+          withCredentials: true
+        });
 
         if (response.data.success) {
           const data = response.data.data;
@@ -56,7 +57,7 @@ export default function AICharge() {
     };
 
     fetchCostData();
-  }, [API_URL, userId]);
+  }, [API_URL]);
 
   const currentMonthLabel = getDateLabel("current");
   const lastMonthLabel = getDateLabel("last");

--- a/src/app/_component/power/BillGraph.tsx
+++ b/src/app/_component/power/BillGraph.tsx
@@ -7,7 +7,6 @@ import styles from "./power.common.module.css";
 const BillGraph = () => {
   const [graphData, setGraphData] = useState([]);
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const userId = 1;
   const display = "bill";
 
   const [isLoading, setIsLoading] = useState(true);
@@ -16,7 +15,10 @@ const BillGraph = () => {
     const fetchGraphData = async () => {
       setIsLoading(true);
       try {
-        const response = await axios.get(`${API_URL}/power/${userId}?display=${display}`);
+        const response = await axios.get(`${API_URL}/power`, {
+          params: { display },
+          withCredentials: true
+        });
 
         if (response.data.success) {
           setGraphData(response.data.data);
@@ -31,7 +33,8 @@ const BillGraph = () => {
     };
 
     fetchGraphData();
-  }, [API_URL, userId, display]);
+  }, [API_URL, display]);
+
   if (isLoading) {
     return (
       <div className={styles.LoadingWrapper}>
@@ -39,6 +42,7 @@ const BillGraph = () => {
       </div>
     );
   }
+
   return <Graph data={graphData} isBillGraph={true} />;
 };
 

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -34,13 +34,15 @@ function ExpectPreChart() {
   const [commentType, setCommentType] = useState<"general" | "expect">("general");
 
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const userId = 1;
 
   useEffect(() => {
     const fetchCostData = async () => {
       setIsLoading(true);
       try {
-        const response = await axios.get(`${API_URL}/power/expect/${userId}`);
+        const response = await axios.get(`${API_URL}/power/expect`, {
+          withCredentials: true
+        });
+
         if (response.data.success) {
           const { expected_cost, last_month_cost, two_month_ago_cost, three_months_ago_cost } =
             response.data.data;
@@ -54,13 +56,16 @@ function ExpectPreChart() {
         } else {
           console.error("전월 요금 데이터 API 호출 실패:", response.data.message);
         }
+      } catch (error) {
+        console.error("API 호출 중 오류 발생:", error);
       } finally {
         setIsLoading(false);
       }
     };
 
     fetchCostData();
-  }, [API_URL, userId]);
+  }, [API_URL]);
+
   // 데이터 로드 후 실행되도록(팁 멘트 디폴트)
   useEffect(() => {
     if (!isLoading && chargeData.lastMonth !== null) {

--- a/src/app/_component/power/UsageGraph.tsx
+++ b/src/app/_component/power/UsageGraph.tsx
@@ -1,17 +1,24 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import Graph from "./Graph";
+import { apiWrapper } from "@/utils/api";
 
 const UsageGraph = () => {
   const [graphData, setGraphData] = useState([]);
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const userId = 1;
   const display = "usage";
 
   useEffect(() => {
     const fetchGraphData = async () => {
       try {
-        const response = await axios.get(`${API_URL}/power/${userId}?display=${display}`);
+        const response = await apiWrapper(
+          () =>
+            axios.get(`${API_URL}/power`, {
+              params: { display },
+              withCredentials: true 
+            }),
+          API_URL
+        );
 
         if (response.data.success) {
           setGraphData(response.data.data);
@@ -24,7 +31,7 @@ const UsageGraph = () => {
     };
 
     fetchGraphData();
-  }, [API_URL, userId, display]);
+  }, [API_URL, display]);
 
   return <Graph data={graphData} isBillGraph={false} />;
 };

--- a/src/app/_component/powerinput/PowerPopup.tsx
+++ b/src/app/_component/powerinput/PowerPopup.tsx
@@ -4,9 +4,10 @@ import styles from "./PowerPopup.module.css";
 import Toast from "@/components/Toast";
 import IconClose from "@/../public/icon/popup_close.svg";
 import InputBottomSheet from "./InputBottomSheet";
+import { apiWrapper } from "@/utils/api";
 
 type PowerPopupProps = {
-  userId: number;
+  // userId: number;
   year: number;
   month: number;
   type: "cost" | "usage";
@@ -17,7 +18,7 @@ type PowerPopupProps = {
 };
 
 const PowerPopup: React.FC<PowerPopupProps> = ({
-  userId,
+  // userId,
   year,
   month,
   type,
@@ -78,7 +79,13 @@ const PowerPopup: React.FC<PowerPopupProps> = ({
         : { year, month, usageAmount: numericValue };
 
     try {
-      const response = await axios.post(`${API_URL}/power/${type}/${userId}`, postData);
+      const response = await apiWrapper(
+        () =>
+          axios.post(`${API_URL}/power/${type}`, postData, {
+            withCredentials: true 
+          }),
+        API_URL
+      );
 
       if (response.status === 200) {
         setToastMessage("저장되었습니다.");

--- a/src/app/_component/powerinput/PowerTable.tsx
+++ b/src/app/_component/powerinput/PowerTable.tsx
@@ -5,6 +5,7 @@ import PowerPopup from "./PowerPopup";
 import styles from "./PowerTable.module.css";
 import IconPlus from "../../../../public/icon/power_plus.svg";
 import IconDropDown from "../../../../public/icon/power_dropdown.svg";
+import { apiWrapper } from "@/utils/api";
 
 type TableRow = {
   year: number;
@@ -55,7 +56,6 @@ const PowerTable: React.FC = () => {
   } | null>(null);
 
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const userId = 1;
 
   const months = useMemo(getLast36Months, []);
   const yearsOptions = useMemo(getYearsOptions, []);
@@ -63,10 +63,16 @@ const PowerTable: React.FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`${API_URL}/power/history/${userId}`);
+        const response = await apiWrapper(
+          () =>
+            axios.get(`${API_URL}/power/history`, {
+              withCredentials: true 
+            }),
+          API_URL
+        );
+
         if (response.data.success) {
           setData(response.data.data);
-          // console.log(response.data.data);
         } else {
           console.error("API 호출 실패:", response.data.message);
         }
@@ -76,7 +82,7 @@ const PowerTable: React.FC = () => {
     };
 
     fetchData();
-  }, [userId]);
+  }, [API_URL]);
 
   const fullData: TableRow[] = useMemo(() => {
     const filteredMonths = selectedYear
@@ -154,7 +160,7 @@ const PowerTable: React.FC = () => {
               <p className={styles.dropdownYear}>{selectedYear ? `${selectedYear}년` : "년도"}</p>
               <IconDropDown
                 className={`${styles.dropDownIcon} ${isDropdownOpen ? styles.open : ""}`}
-              />{" "}
+              />
             </span>
             {isDropdownOpen && (
               <div className={styles.dropdownMenu}>
@@ -284,7 +290,7 @@ const PowerTable: React.FC = () => {
       </table>
       {popupInfo && (
         <PowerPopup
-          userId={userId}
+          // userId={userId}
           year={popupInfo.year}
           month={popupInfo.month}
           type={popupInfo.type}

--- a/src/app/auth/google/callback/page.tsx
+++ b/src/app/auth/google/callback/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+import LoadingDots from "@/components/LoadingDots";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function GoogleCallbackPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.push("/main");
+  }, [router]);
+  return (
+    <div
+      style={{ height: "500px", display: "flex", justifyContent: "center", alignItems: "center" }}
+    >
+      <LoadingDots />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import IconGoogle from "@/../public/icon/login_google.svg";
 import IconLogo from "@/../public/icon/login_logo.svg";
 import TextLogo from "@/../public/icon/login_textLogo.svg";
 
 import styles from "./LoginPage.module.css";
+import LoginBtn from "./_component/login/LoginBtn";
 
 export default function Login() {
   return (
@@ -22,10 +22,7 @@ export default function Login() {
         </div>
         <div className={styles.loginContainer}>
           <p className={styles.loginMent}>지금 바로 시작해보세요!</p>
-          <button type="button" className={styles.loginBtn}>
-            <IconGoogle className={styles.googleIcon} />
-            <p className={styles.googleMent}>Google 계정으로 로그인</p>
-          </button>
+          <LoginBtn />
         </div>
       </div>
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import IconLogo from "@/../public/icon/login_logo.svg";
 import TextLogo from "@/../public/icon/login_textLogo.svg";
 
 import styles from "./LoginPage.module.css";
-import LoginBtn from "./_component/login/LoginBtn";
+import LoginBtn from "@/app/_component/login/LoginBtn";
 
 export default function Login() {
   return (

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,7 +2,12 @@
 import React, { useState } from "react";
 import styles from "./Profile.module.css";
 import IconLogo from "@/../public/icon/login_logo.svg";
+import { useRouter } from "next/navigation";
 export default function Profile() {
+  const router = useRouter();
+  const goHome = () => {
+    router.push("/main");
+  };
   // 전기요금 납부일
   const [paymentDay, setPaymentDay] = useState<number>(1);
   // 거주 인원
@@ -66,7 +71,7 @@ export default function Profile() {
             </p>
           </div>
         </div>
-        <div className={styles.btnWrap}>
+        <div className={styles.btnWrap} onClick={goHome}>
           <button type="button" className={styles.homeBtn}>
             그린스파크 바로가기
           </button>

--- a/src/components/HomeBtn.tsx
+++ b/src/components/HomeBtn.tsx
@@ -7,7 +7,7 @@ const HomeBtn = () => {
   const router = useRouter();
 
   const goToHome = () => {
-    router.push("/");
+    router.push("/main");
   };
 
   return (

--- a/src/components/TopBarToHome.tsx
+++ b/src/components/TopBarToHome.tsx
@@ -11,7 +11,7 @@ interface TopBarProps {
 export default function TopBar({ text }: TopBarProps) {
   const router = useRouter();
   const handleBack = () => {
-    router.push("/");
+    router.push("/main");
   };
 
   return (

--- a/src/components/bottomNav.tsx
+++ b/src/components/bottomNav.tsx
@@ -27,7 +27,7 @@ export default function BottomNav() {
       setActiveButton("power");
     } else if (pathname.startsWith("/book")) {
       setActiveButton("book");
-    } else if (pathname === "/") {
+    } else if (pathname === "/main") {
       setActiveButton("home");
     } else if (pathname.startsWith("/list")) {
       setActiveButton("list");
@@ -72,7 +72,7 @@ export default function BottomNav() {
       <div className={styles.menuHomeContainer}>
         <div
           className={`${styles.menuHome} ${activeButton === "home" ? styles.menuHomeActive : ""}`}
-          onClick={() => handleButtonClick("home", "/")}
+          onClick={() => handleButtonClick("home", "/main")}
         >
           {activeButton === "home" ? (
             <IconClickHome className={styles.homeIcon} />
@@ -88,11 +88,7 @@ export default function BottomNav() {
         ) : (
           <IconAppliance className={styles.icon} />
         )}
-        <p
-          className={`${styles.menuName} ${
-            activeButton === "list" ? styles.menuNameActive : ""
-          }`}
-        >
+        <p className={`${styles.menuName} ${activeButton === "list" ? styles.menuNameActive : ""}`}>
           가전
         </p>
       </div>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,34 @@
+import axios from "axios";
+
+/**
+ * Reissue the authentication token.
+ * @param apiUrl - The base URL for the API.
+ * @returns {Promise<boolean>} - Returns `true` if the token reissue was successful, otherwise `false`.
+ */
+export const reissueToken = async (apiUrl: string | undefined): Promise<boolean> => {
+  if (!apiUrl) {
+    console.error("API URL이 정의되지 않았습니다. 환경변수를 확인하세요.");
+    return false;
+  }
+
+  try {
+    const response = await axios.post(`${apiUrl}/reissue`, {}, { withCredentials: true });
+
+    // response.data 및 success 값 검증
+    if (response?.data && typeof response.data.success === "boolean") {
+      if (response.data.success) {
+        console.log("토큰 갱신 성공");
+        return true;
+      } else {
+        console.error("토큰 갱신 실패:", response.data.message || "Unknown error");
+        return false;
+      }
+    } else {
+      console.error("응답 데이터가 예상한 형식이 아닙니다:", response?.data);
+      return false;
+    }
+  } catch (error) {
+    console.error("토큰 갱신 중 오류 발생:", error);
+    return false;
+  }
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -32,3 +32,21 @@ export const reissueToken = async (apiUrl: string | undefined): Promise<boolean>
     return false;
   }
 };
+
+export const apiWrapper = async (apiCall: () => Promise<any>, apiUrl: string | undefined) => {
+  if (!apiUrl) {
+    console.error("API URL이 정의되지 않았습니다. 환경변수를 확인하세요.");
+    throw new Error("API URL is undefined. Please check your environment variables.");
+  }
+
+  try {
+    const tokenReissued = await reissueToken(apiUrl);
+    if (!tokenReissued) {
+      throw new Error("토큰 갱신에 실패했습니다.");
+    }
+    return await apiCall();
+  } catch (error) {
+    console.error("API 호출 중 오류 발생:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## 📝 PR 유형
- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #85 

## ✅ 작업 목록
- 구글 로그인 구현 (/api/login)
<img width="634" alt="image" src="https://github.com/user-attachments/assets/31788394-3374-49cd-89d4-029e5a669d7b">

1. (프론트) 소셜로그인 버튼 클릭 시 하이퍼링크로 백엔드 API GET 요청
2. (백엔드) -> (외부) 구글 로그인 세션 열림
3. (외부) 로그인 시 나오는 인가 코드 발급 -> (백엔드) 인가 코드로 토큰 요청, 토큰 발급, 토큰으로 유저 요청, 유저 정보 발급
4. (백엔드) JWT 토큰을 브라우저 쿠키에 저장
5. (프론트) 쿠키 사용 불가하기 때문에 axios의 withCredentials 옵션 수동으로 추가하여 헤더에 쿠키 포함하여 다른 API 요청 (httpOnly, Secure 쿠키라 접근 불가능)

<img width="555" alt="image" src="https://github.com/user-attachments/assets/5bd3ca94-20f5-4f31-a446-c99892979845">


- 토큰 갱신 (/api/reissue)
원래 백엔드가 설계한 로직에 따르면, refresh 토큰만 있을 경우 401 인증 오류가 나와 /reissue 로 토큰을 재발급 받을 수 있었습니다. 하지만, 401 에러가 안 나오는 이슈가 있고 백엔드와 논의한 결과 배포 이후에 한 번 더 확인하기로 하고 일단 어떤 api든 호출 이전 reissue 호출로 재발급을 받는 로직입니다.

1. 개별 API일 경우 (프론트 단에서 한 페이지 내에 인증이 필요한 하나의 API를 호출할 경우)
중복 로직을 지우고자, utils/api.ts 파일에 함수를 만들었습니다.

**reissueToken**
```
export const reissueToken = async (apiUrl: string | undefined): Promise<boolean> => {
  if (!apiUrl) {
    console.error("API URL이 정의되지 않았습니다. 환경변수를 확인하세요.");
    return false;
  }

  try {
    const response = await axios.post(`${apiUrl}/reissue`, {}, { withCredentials: true });

    // response.data 및 success 값 검증
    if (response?.data && typeof response.data.success === "boolean") {
      if (response.data.success) {
        console.log("토큰 갱신 성공");
        return true;
      } else {
        console.error("토큰 갱신 실패:", response.data.message || "Unknown error");
        return false;
      }
    } else {
      console.error("응답 데이터가 예상한 형식이 아닙니다:", response?.data);
      return false;
    }
  } catch (error) {
    console.error("토큰 갱신 중 오류 발생:", error);
    return false;
  }
};
```
withCredentials 옵션이 포함되어 있어 호출 시 자동으로 토큰 갱신 api를 정상적으로 호출합니다. 또한, API URL이 환경변수에 없을 것을 대비하여 undefined일 경우 콘솔에서 에러를 보여줍니다.


**apiWrapper**
```
export const apiWrapper = async (apiCall: () => Promise<any>, apiUrl: string | undefined) => {
  if (!apiUrl) {
    console.error("API URL이 정의되지 않았습니다. 환경변수를 확인하세요.");
    throw new Error("API URL is undefined. Please check your environment variables.");
  }

  try {
    const tokenReissued = await reissueToken(apiUrl);
    if (!tokenReissued) {
      throw new Error("토큰 갱신에 실패했습니다.");
    }
    return await apiCall();
  } catch (error) {
    console.error("API 호출 중 오류 발생:", error);
    throw error;
  }
};
```
apiWrapper는 매개변수로 apiCall을 받는 콜백함수로, 위의 reissueToken 함수를 호출하는 로직입니다. 따라서, 개별 api 호출일 경우 apiWrapper를 이용하면 됩니다.

2. 페이지에서 호출할 경우 (프론트 단에서 한 페이지 내에 인증이 필요한 여러 API를 호출할 경우)
```
  useEffect(() => {
    const renewToken = async () => {
      try {
        const response = await axios.post(`${API_URL}/reissue`, {}, { withCredentials: true });
        if (response.data.success) {
          console.log("토큰 갱신 성공");
          setTokenRenewed(true);
        } else {
          console.error("토큰 갱신 실패:", response.data.message);
        }
      } catch (error) {
        console.error("토큰 갱신 중 오류 발생:", error);
      }
    };

    renewToken();
  }, [API_URL]);
```

페이지 마다 API를 부르는 로직이 조금씩 달라, 해당 페이지에서 한 번만 컴포넌트 마운트시 reissue 경로로 호출하는 코드입니다.

## 🍰 논의사항
1. withCredentials 옵션 추가해도 헤더에 포함되지 않는 이슈가 있었는데, 백엔드 측에서 서브도메인 추가 후 이 이슈는 해결됐습니다.
2. 테스트 하다가 파워 페이지에서 파워 입력 시 처음 빈 셀에 입력을 하면 새로고침을 해야 반영되는 이슈가 있습니다.
4. 네트워크 탭에서 reissue 호출을 여러번 하지 않도록 만드느라 저런 식으로 구현했는데, 추후에 테스트하다가 혹시 중복 호출이 된다면 알려주시면 감사하겠습니다!
5. 현재 보안 정책 때문인지, 정확한 이유는 모르겠지만 개발할 때 시크릿 모드에서는 withCredentials 옵션이 적용되지 않는 것 같습니다.

## 📷 ETC
https://github.com/user-attachments/assets/db8de4c3-7ca5-407e-b02a-136c62ccfd72



