### PR TITLE
Fix: 파워 관련 에러 해결

### DIFF
--- a/src/app/_component/home/HomePower.tsx
+++ b/src/app/_component/home/HomePower.tsx
@@ -30,7 +30,6 @@ export default function HomePower() {
 
   // api 통신
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
-  const userId = 1;
 
   useEffect(() => {
     const fetchCostData = async () => {
@@ -69,7 +68,7 @@ export default function HomePower() {
     };
 
     fetchCostData();
-  }, [API_URL, userId]);
+  }, [API_URL]);
 
   // 요금 변동 메시지 설정
   const renderComment = () => {
@@ -150,12 +149,13 @@ export default function HomePower() {
             </p>
             <p className={styles.cost}>
               <span className={styles.costGreen}>
-                {chargeData && chargeData.currentMonth !== null
+                {chargeData && chargeData.currentMonth !== null && chargeData.currentMonth !== 0
                   ? chargeData.currentMonth.toLocaleString()
                   : "?,???"}
               </span>{" "}
               원
             </p>
+
             <div className={styles.comment}>
               <IconComment className={styles.iconComment} />
               {renderComment()}

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -67,11 +67,13 @@ function ExpectPreChart() {
   }, [API_URL]);
 
   // 데이터 로드 후 실행되도록(팁 멘트 디폴트)
+  const [selectedMonth, setSelectedMonth] = useState("lastMonth");
+
   useEffect(() => {
-    if (!isLoading && chargeData.lastMonth !== null) {
+    if (selectedMonth === "lastMonth" && !isLoading) {
       handleChartClick("lastMonth");
     }
-  }, [isLoading, chargeData]);
+  }, [isLoading]);
 
   const determineDifferenceType = (pre: number | null, current: number | null): DifferenceType => {
     if (pre === null && current === null) return "noMonths";
@@ -122,7 +124,6 @@ function ExpectPreChart() {
 
   const [preMonthLabel, setPreMonthLabel] = useState("");
   const [currentMonthLabel, setCurrentMonthLabel] = useState("");
-  const [selectedMonth, setSelectedMonth] = useState<string | null>(null);
 
   const handleChartClick = (type: "twoMonth" | "lastMonth" | "currentMonth") => {
     let pre: number | null;
@@ -137,7 +138,7 @@ function ExpectPreChart() {
         setCommentType("general");
         setPreMonthLabel(getDateLabel("threeMonths").monthLabel);
         setCurrentMonthLabel(getDateLabel("twoMonths").monthLabel);
-        setSelectedMonth("twoMonths");
+        setSelectedMonth("twoMonth");
 
         break;
       case "lastMonth":
@@ -325,23 +326,24 @@ function ExpectPreChart() {
     }
   };
 
-  const SpeechBalloon: React.FC<{ tailX: number }> = ({ tailX }) => (
+  const SpeechBalloon: React.FC<{ tailX: number; height: number }> = ({ tailX, height }) => (
     <svg
       width="243"
-      height="95"
-      viewBox="0 0 243 95"
+      height={height}
+      viewBox={`0 0 243 ${height}`}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <rect y="12" width="243" height="83" rx="10" fill="#F1F3F5" />
-
+      <rect y="12" width="243" height={height - 12} rx="10" fill="#F1F3F5" />
       <path d={`M${tailX} 0 L${tailX + 8.227} 12 H${tailX - 8.227} L${tailX} 0Z`} fill="#F1F3F5" />
     </svg>
   );
 
+  const tipHeight = differenceType === "noMonths" || differenceType === "noCurrentMonth" ? 56 : 95;
+
   //   팁멘트 아이콘
   const TipMentIcon = () => {
-    return <SpeechBalloon tailX={tailPosition} />;
+    return <SpeechBalloon tailX={tailPosition} height={tipHeight} />;
   };
 
   return (
@@ -349,9 +351,7 @@ function ExpectPreChart() {
       <div className={styles.chartContainer}>
         {/* 전전월 */}
         <div className={styles.chartUnit} onClick={() => handleChartClick("twoMonth")}>
-          <p
-            className={`${styles.boxCost} ${chargeData?.twoMonthsAgo === null ? styles.costText : ""}`}
-          >
+          <p className={styles.boxCost}>
             {chargeData?.twoMonthsAgo?.toLocaleString() ?? "?,???"}원
           </p>
           <div className={`${styles.chartColor} ${getChartColorClass(chargeData.twoMonthsAgo)}`}>
@@ -383,18 +383,14 @@ function ExpectPreChart() {
             </div>
           </div>
           <p
-            className={`${styles.monthLabel} ${selectedMonth === "twoMonths" ? styles.monthLabelClick : ""}`}
+            className={`${styles.monthLabel} ${selectedMonth === "twoMonth" ? styles.monthLabelClick : ""}`}
           >
             {`${twoMonthsDate.monthLabel}월`}
           </p>{" "}
         </div>
         {/* 전월 */}
         <div className={styles.chartUnit} onClick={() => handleChartClick("lastMonth")}>
-          <p
-            className={`${styles.boxCost} ${chargeData?.lastMonth === null ? styles.costText : ""}`}
-          >
-            {chargeData?.lastMonth?.toLocaleString() ?? "?,???"}원
-          </p>
+          <p className={styles.boxCost}>{chargeData?.lastMonth?.toLocaleString() ?? "?,???"}원</p>
           <div className={`${styles.chartColor} ${getChartColorClass(chargeData.lastMonth)}`}>
             <div className={styles.chartBox}>
               <p className={styles.chartBoxText}>{`${twoMonthsDate.monthLabel}월 대비`}</p>
@@ -432,9 +428,7 @@ function ExpectPreChart() {
         {/* 예상요금 */}
         <div className={styles.chartUnit} onClick={() => handleChartClick("currentMonth")}>
           <p className={styles.infoText}>예상요금</p>
-          <p
-            className={`${styles.boxCost} ${chargeData?.expectedCost === null ? styles.costText : ""}`}
-          >
+          <p className={styles.boxCost}>
             {chargeData?.expectedCost?.toLocaleString() ?? "?,???"}원
           </p>
           <div className={`${styles.chartColor} ${getChartColorClass(chargeData.expectedCost)}`}>

--- a/src/app/_component/power/expectPreCost.module.css
+++ b/src/app/_component/power/expectPreCost.module.css
@@ -246,16 +246,14 @@
   margin-top: 1.4rem;
   position: relative;
 }
-
-.tipMentBig {
+.tipMent {
   color: #000;
   font-size: 1.2rem;
   font-style: normal;
   font-weight: 400;
-  line-height: normal;
+  line-height: 1.4;
 
   position: absolute;
-  top: 2rem;
   width: 21rem;
   z-index: 1;
   height: 5rem;
@@ -265,23 +263,11 @@
   align-items: center;
   justify-content: center;
 }
+.tipMentBig {
+  top: 2rem;
+}
 .tipMentSmall {
-  color: #000;
-  font-size: 1.2rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: normal;
-
-  position: absolute;
-  top: 0.2rem;
-  width: 21rem;
-  z-index: 1;
-  height: 5rem;
-  padding: 1rem;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  top: 0.1rem;
 }
 .LoadingWrapper {
   display: flex;

--- a/src/app/_component/powerinput/PowerTable.tsx
+++ b/src/app/_component/powerinput/PowerTable.tsx
@@ -66,7 +66,7 @@ const PowerTable: React.FC = () => {
         const response = await apiWrapper(
           () =>
             axios.get(`${API_URL}/power/history`, {
-              withCredentials: true 
+              withCredentials: true
             }),
           API_URL
         );
@@ -137,14 +137,30 @@ const PowerTable: React.FC = () => {
   };
 
   const handleSave = (year: number, month: number, type: "cost" | "usage", newValue: number) => {
-    setData(prevData =>
-      prevData.map(row => {
-        if (row.year === year && row.month === month) {
-          return type === "cost" ? { ...row, cost: newValue } : { ...row, usage_amount: newValue };
-        }
-        return row;
-      })
-    );
+    setData(prevData => {
+      // 기존에 존재하는 데이터인지 확인
+      const rowExists = prevData.some(row => row.year === year && row.month === month);
+
+      if (rowExists) {
+        // 기존 데이터 수정
+        return prevData.map(row => {
+          if (row.year === year && row.month === month) {
+            return type === "cost"
+              ? { ...row, cost: newValue }
+              : { ...row, usage_amount: newValue };
+          }
+          return row;
+        });
+      } else {
+        // 새로운 데이터 추가
+        const newRow: TableRow = {
+          year,
+          month,
+          ...(type === "cost" ? { cost: newValue } : { usage_amount: newValue })
+        };
+        return [...prevData, newRow];
+      }
+    });
   };
 
   const closePopup = () => {

--- a/src/components/bottomNav.tsx
+++ b/src/components/bottomNav.tsx
@@ -93,7 +93,7 @@ export default function BottomNav() {
         </p>
       </div>
 
-      <div className={styles.navBtn} onClick={() => handleButtonClick("my", "/my")}>
+      <div className={styles.navBtn} onClick={() => handleButtonClick("my", "/my/main")}>
         {activeButton === "my" ? (
           <IconClickMy className={styles.icon} />
         ) : (


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
<!-- ex) close #1 -->
#92 

## ✅ 작업 목록
<!-- 이슈 작업한 내용 -->
### 1. 초기 데이터 없는 경우 expect api 500에러
- 백엔드에서 메세지와 500에러로 함께 보내주고 있었는데 둘 다 없는 경우에도 0으로 보내주는 것으로 수정했습니다
- 그에 맞게 0은 null로 간주하도록 코드 수정했습니다(홈의 파워 부분에서는 적용 안되어있었음)

### 2. 파워 예상요금 차트 새로고침 및 스타일 수정
- 새로고침 했을 때 지난달 차트(가운데)가 활성화 되어야 하는데 말풍선 아이콘을 제외한 비교 멘트(팁 멘트), monthLabel는 활성화 되지 않았습니다.
- useState를 초기화할 때 selectedMonth를 'lastMonth'로 설정했습니다.(초기 상태 설정)
- 기존에는 멘트 길이에 상관 없이 height를 동일하게 설정했는데 케이스에 따라 height를 동적으로 설정했습니다.

### 3. 파워 입력 후 새로고침 에러
- 새로 입력하는 셀의 경우에는 입력값이 바로 적용되지 않고 새로고침 해야 적용되는 이슈가 있었습니다.(기존 값을 수정할 때는 정상적으로 바로 적용됨)
- 기존에는 수정하는 경우에 동작하는 코드만 작성되어 있었고 새로운 값을 입력할 때도 동작하도록 수정했습니다.

### 4. 하단바 마이페이지 경로 수정
- `/my `-> `/my/main `

## 🍰 논의사항
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC
<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->

