### PR TITLE
Feat: 퀴즈 api 연결

### DIFF
--- a/src/app/(common-layout)/quiz/[questionId]/answer/page.tsx
+++ b/src/app/(common-layout)/quiz/[questionId]/answer/page.tsx
@@ -2,7 +2,6 @@
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import QuizAnswer from "@/app/_component/quiz/QuizAnswer";
-import { QuizProvider } from "@/context/QuizContext";
 
 export default function Page() {
   const { questionId } = useParams();
@@ -14,9 +13,5 @@ export default function Page() {
     }
   }, [questionId]);
 
-  return (
-    <>
-      <QuizProvider>{id ? <QuizAnswer id={id} /> : <p>Loading...</p>}</QuizProvider>
-    </>
-  );
+  return <>{id ? <QuizAnswer id={id} /> : <p>Loading...</p>}</>;
 }

--- a/src/app/(common-layout)/quiz/[questionId]/answer/page.tsx
+++ b/src/app/(common-layout)/quiz/[questionId]/answer/page.tsx
@@ -2,6 +2,7 @@
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import QuizAnswer from "@/app/_component/quiz/QuizAnswer";
+import { QuizProvider } from "@/context/QuizContext";
 
 export default function Page() {
   const { questionId } = useParams();
@@ -13,5 +14,9 @@ export default function Page() {
     }
   }, [questionId]);
 
-  return <>{id ? <QuizAnswer id={id} /> : <p>Loading...</p>} </>;
+  return (
+    <>
+      <QuizProvider>{id ? <QuizAnswer id={id} /> : <p>Loading...</p>}</QuizProvider>
+    </>
+  );
 }

--- a/src/app/(common-layout)/quiz/[questionId]/page.tsx
+++ b/src/app/(common-layout)/quiz/[questionId]/page.tsx
@@ -1,17 +1,28 @@
 "use client";
-import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useParams, useSearchParams } from "next/navigation";
 import QuizSubmit from "@/app/_component/quiz/QuizSubmit";
+import { QuizProvider } from "@/context/QuizContext";
 
 export default function Page() {
   const { questionId } = useParams();
-  const [id, setId] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const quizIdParam = searchParams.get("quizId");
 
-  useEffect(() => {
-    if (questionId) {
-      setId(Array.isArray(questionId) ? questionId[0] : questionId);
-    }
-  }, [questionId]);
+  const questionIdNumber = Array.isArray(questionId)
+    ? parseInt(questionId[0])
+    : parseInt(questionId);
 
-  return <>{id ? <QuizSubmit id={id} /> : <p>Loading...</p>} </>;
+  const quizId = quizIdParam ? parseInt(quizIdParam) : null;
+
+  return (
+    <>
+      <QuizProvider>
+        {quizId && questionIdNumber ? (
+          <QuizSubmit questionId={questionIdNumber} quizId={quizId} />
+        ) : (
+          <p>Loading...</p>
+        )}
+      </QuizProvider>
+    </>
+  );
 }

--- a/src/app/(common-layout)/quiz/[questionId]/page.tsx
+++ b/src/app/(common-layout)/quiz/[questionId]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useParams, useSearchParams } from "next/navigation";
 import QuizSubmit from "@/app/_component/quiz/QuizSubmit";
-import { QuizProvider } from "@/context/QuizContext";
 
 export default function Page() {
   const { questionId } = useParams();
@@ -16,13 +15,11 @@ export default function Page() {
 
   return (
     <>
-      <QuizProvider>
-        {quizId && questionIdNumber ? (
-          <QuizSubmit questionId={questionIdNumber} quizId={quizId} />
-        ) : (
-          <p>Loading...</p>
-        )}
-      </QuizProvider>
+      {quizId && questionIdNumber ? (
+        <QuizSubmit questionId={questionIdNumber} quizId={quizId} />
+      ) : (
+        <p>Loading...</p>
+      )}
     </>
   );
 }

--- a/src/app/(common-layout)/quiz/layout.tsx
+++ b/src/app/(common-layout)/quiz/layout.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import TopBar from "@/components/TopBar";
+import { QuizProvider } from "@/context/QuizContext";
 
 export default function Layout({
   children
@@ -7,8 +10,10 @@ export default function Layout({
 }>) {
   return (
     <>
-      <TopBar text={"에너지 퀴즈"} />
-      {children}
+      <QuizProvider>
+        <TopBar text={"에너지 퀴즈"} />
+        {children}{" "}
+      </QuizProvider>
     </>
   );
 }

--- a/src/app/(common-layout)/quiz/layout.tsx
+++ b/src/app/(common-layout)/quiz/layout.tsx
@@ -12,7 +12,7 @@ export default function Layout({
     <>
       <QuizProvider>
         <TopBar text={"에너지 퀴즈"} />
-        {children}{" "}
+        {children}
       </QuizProvider>
     </>
   );

--- a/src/app/_component/quiz/Popup.tsx
+++ b/src/app/_component/quiz/Popup.tsx
@@ -1,35 +1,22 @@
 import React from "react";
-import { useState } from "react";
 import styles from "./Popup.module.css";
 import IconClose from "@/../public/icon/popup_close.svg";
 import IconMent from "@/../public/icon/quiz_ment.svg";
 
-interface PopupProps {
-  onClose: () => void;
-  questionId: number | null;
-}
-interface QuizData {
-  // questionId: number;
-  isCorrect: boolean;
+export interface QuizData {
+  quizId: number;
   question: string;
-  correctAnswer: string;
-  selectedAnswer: string;
   explanation: string;
+  answer: string;
 }
 
-const Popup: React.FC<PopupProps> = ({ onClose, questionId }: PopupProps) => {
-  const mockData: QuizData = {
-    // questionId: 1,
-    isCorrect: true,
-    question: "가정에서 에너지를 절약하기 위한 올바른 방법은 무엇인가요?",
-    correctAnswer: "전등을 LED로 교체하기",
-    selectedAnswer: "에어컨을 밤새 켜두기",
-    explanation:
-      "LED 전등은 백열등보다 훨씬 적은 전력을 소비하고 수명이 길어요! 환경에도 좋고 비용도 절약할 수 있는 방법이에요!"
-  };
+interface PopupProps {
+  quizData: QuizData;
+  questionId: number;
+  onClose: () => void;
+}
 
-  const [quizData] = useState<QuizData>(mockData);
-
+const Popup: React.FC<PopupProps> = ({ quizData, questionId, onClose }) => {
   return (
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.popup}>
@@ -44,13 +31,8 @@ const Popup: React.FC<PopupProps> = ({ onClose, questionId }: PopupProps) => {
 
             <div className={styles.answerContainer}>
               <p className={styles.quizAnswer}>
-                <span className={styles.textGreen}>정답 </span>: {quizData.correctAnswer}
+                <span className={styles.textGreen}>정답 </span>: {quizData.answer}
               </p>
-              {!quizData.isCorrect && (
-                <p className={styles.quizAnswer}>
-                  <span className={styles.textRed}>오답 </span>: {quizData.selectedAnswer}
-                </p>
-              )}
             </div>
 
             <div className={styles.expBox}>

--- a/src/app/_component/quiz/QuizAnswer.module.css
+++ b/src/app/_component/quiz/QuizAnswer.module.css
@@ -124,7 +124,7 @@
   font-size: 12px;
   font-style: normal;
   font-weight: 500;
-  line-height: normal;
+  line-height: 1.5;
 }
 
 .iconArrow {
@@ -135,17 +135,20 @@
 
 .homeBtn {
   display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  justify-content: space-between;
-  width: 8rem;
-  margin-left: 15rem;
-  margin-top: 1rem;
+  float: right;
+  width: 27.7rem;
+  height: 3.8rem;
+  border-radius: 1em;
+  border: none;
+  background-color: #19e407;
+  color: #fff;
+  text-align: center;
+  font-size: 1.6rem;
+  font-weight: 400;
+  box-shadow: 0 0 0.4em 0 #d4ddcf;
   cursor: pointer;
-}
-.homeBtn p {
-  color: #000;
-
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 600;
+  margin-top: 4rem;
 }

--- a/src/app/_component/quiz/QuizAnswer.tsx
+++ b/src/app/_component/quiz/QuizAnswer.tsx
@@ -1,12 +1,13 @@
 "use client";
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useQuizContext } from "@/context/QuizContext";
+import axios from "axios";
 import Box from "@/components/Box";
 import styles from "./QuizAnswer.module.css";
 import IconMent from "@/../public/icon/quiz_ment.svg";
 import IconCorrect from "@/../public/icon/quiz_correct.svg";
 import IconWrong from "@/../public/icon/quiz_wrong.svg";
-import IconArrow from "@/../public/icon/arrow_left.svg";
 
 interface QuizAnswerProps {
   id: string;
@@ -23,14 +24,39 @@ export default function QuizAnswer({ id }: QuizAnswerProps) {
       explanation,
       isCorrect
     });
-  }, [question, userAnswer, correctAnswer, explanation, isCorrect]);
+
+    const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+    if (isCorrect === "true") {
+      const updatePoint = async () => {
+        try {
+          const response = await axios.post(
+            `${API_URL}/point/update`,
+            {
+              pointAmount: 100,
+              event: "오늘의 퀴즈 완료"
+            },
+            {
+              withCredentials: true
+            }
+          );
+          console.log("포인트 업데이트 성공:", response.data);
+        } catch (error) {
+          console.error("포인트 업데이트 실패:", error);
+        }
+      };
+
+      updatePoint();
+    }
+  }, [isCorrect]);
 
   if (!question || !userAnswer || !correctAnswer || !explanation || !isCorrect) {
     return <p>로딩 중...</p>;
   }
 
+  const router = useRouter();
   const goToQuizHome = () => {
-    window.history.back();
+    router.push(`/quiz`);
   };
 
   return (
@@ -81,7 +107,6 @@ export default function QuizAnswer({ id }: QuizAnswerProps) {
           </div>
           <div className={styles.homeBtn} onClick={goToQuizHome}>
             <p>퀴즈 홈으로 가기</p>
-            <IconArrow className={styles.iconArrow} />
           </div>
         </div>
       </Box>

--- a/src/app/_component/quiz/QuizAnswer.tsx
+++ b/src/app/_component/quiz/QuizAnswer.tsx
@@ -1,7 +1,6 @@
 "use client";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-
+import { useEffect } from "react";
+import { useQuizContext } from "@/context/QuizContext";
 import Box from "@/components/Box";
 import styles from "./QuizAnswer.module.css";
 import IconMent from "@/../public/icon/quiz_ment.svg";
@@ -9,33 +8,29 @@ import IconCorrect from "@/../public/icon/quiz_correct.svg";
 import IconWrong from "@/../public/icon/quiz_wrong.svg";
 import IconArrow from "@/../public/icon/arrow_left.svg";
 
-interface QuizData {
-  // questionId: number;
-  isCorrect: boolean;
-  question: string;
-  correctAnswer: string;
-  selectedAnswer: string;
-  explanation: string;
-}
 interface QuizAnswerProps {
   id: string;
 }
+
 export default function QuizAnswer({ id }: QuizAnswerProps) {
-  const mockData: QuizData = {
-    // questionId: 1,
-    isCorrect: true,
-    question: "가정에서 에너지를 절약하기 위한 올바른 방법은 무엇인가요?",
-    correctAnswer: "전등을 LED로 교체하기",
-    selectedAnswer: "에어컨을 밤새 켜두기",
-    explanation:
-      "LED 전등은 백열등보다 훨씬 적은 전력을 소비하고 수명이 길어요! 환경에도 좋고 비용도 절약할 수 있는 방법이에요!"
-  };
+  const { question, userAnswer, correctAnswer, explanation, isCorrect } = useQuizContext();
 
-  const [quizData] = useState<QuizData>(mockData);
+  useEffect(() => {
+    console.log("QuizAnswer Context Data:", {
+      question,
+      userAnswer,
+      correctAnswer,
+      explanation,
+      isCorrect
+    });
+  }, [question, userAnswer, correctAnswer, explanation, isCorrect]);
 
-  const router = useRouter();
+  if (!question || !userAnswer || !correctAnswer || !explanation || !isCorrect) {
+    return <p>로딩 중...</p>;
+  }
+
   const goToQuizHome = () => {
-    router.push(`/quiz`);
+    window.history.back();
   };
 
   return (
@@ -47,7 +42,7 @@ export default function QuizAnswer({ id }: QuizAnswerProps) {
             <p>Q{id}</p>
           </div>
 
-          {quizData.isCorrect ? (
+          {isCorrect === "true" ? (
             <>
               <p className={styles.correctTitle}>
                 <span className={styles.textGreen}>정답</span>이에요!
@@ -67,24 +62,24 @@ export default function QuizAnswer({ id }: QuizAnswerProps) {
             </>
           )}
 
-          <p className={styles.quizTitle}>{quizData.question}</p>
+          <p className={styles.quizTitle}>{question}</p>
 
           <div className={styles.answerContainer}>
             <p className={styles.quizAnswer}>
-              <span className={styles.textGreen}>정답 </span>: {quizData.correctAnswer}
+              <span className={styles.textGreen}>정답 </span>: {correctAnswer}
             </p>
-            {!quizData.isCorrect && (
+            {isCorrect === "false" && (
               <p className={styles.quizAnswer}>
-                <span className={styles.textRed}>오답 </span>: {quizData.selectedAnswer}
+                <span className={styles.textRed}>오답 </span>: {userAnswer}
               </p>
             )}
           </div>
 
           <div className={styles.expBox}>
             <p className={styles.expTitle}>해설</p>
-            <p className={styles.expBody}>{quizData.explanation}</p>
+            <p className={styles.expBody}>{explanation}</p>
           </div>
-          <div className={styles.homeBtn} onClick={() => goToQuizHome()}>
+          <div className={styles.homeBtn} onClick={goToQuizHome}>
             <p>퀴즈 홈으로 가기</p>
             <IconArrow className={styles.iconArrow} />
           </div>

--- a/src/app/_component/quiz/QuizMain.tsx
+++ b/src/app/_component/quiz/QuizMain.tsx
@@ -1,18 +1,58 @@
 "use client";
+import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import axios from "axios";
 import Box from "@/components/Box";
 import Popup from "./Popup";
 import styles from "./QuizMain.module.css";
 import IconPower from "@/../public/icon/quiz_power.svg";
 import IconArrow from "@/../public/icon/arrow_left.svg";
 
+interface QuizData {
+  questionId: number;
+  quizId: number;
+  solved: boolean;
+  question: string;
+  explanation: string;
+  answer: string;
+}
+
 export default function QuizMain() {
   const router = useRouter();
-  const [quizStatus, setQuizStatus] = useState({
-    quiz1: true,
-    quiz2: false
-  });
+
+  const [quizStatus, setQuizStatus] = useState<QuizData[]>([]);
+
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+  useEffect(() => {
+    const fetchCostData = async () => {
+      try {
+        const response = await axios.get(`${API_URL}/quiz`, {
+          withCredentials: true
+        });
+
+        if (response.data.success) {
+          const quizData = response.data.data.map((item: any, index: number) => ({
+            questionId: index + 1,
+            quizId: item.quiz.quizId,
+            solved: item.solved,
+            question: item.quiz.question,
+            explanation: item.quiz.explanation,
+            answer: item.quiz.answer
+          }));
+
+          setQuizStatus(quizData);
+          console.log(quizData);
+        } else {
+          console.error("API 호출 실패:", response.data.message);
+        }
+      } catch (error) {
+        console.error("API 호출 중 오류 발생:", error);
+      }
+    };
+
+    fetchCostData();
+  }, [API_URL]);
 
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [currentQuestionId, setCurrentQuestionId] = useState<number | null>(null);
@@ -25,11 +65,44 @@ export default function QuizMain() {
   const closePopup = () => setIsPopupOpen(false);
 
   const handleQuizClick = (questionId: number) => {
-    router.push(`/quiz/${questionId}`);
+    const quiz = quizStatus.find(q => q.questionId === questionId);
+
+    if (quiz) {
+      router.push(`/quiz/${questionId.toString()}?quizId=${quiz.quizId}`);
+    } else {
+      console.error("Quiz not found!");
+    }
+  };
+
+  const isQuizSolved = (questionId: number) => {
+    const quiz = quizStatus.find(q => q.questionId === questionId);
+    return quiz ? quiz.solved : false;
   };
 
   const getQuizMent = () => {
-    if (!quizStatus.quiz1 && !quizStatus.quiz2) {
+    const allSolved = quizStatus.every(quiz => quiz.solved);
+    const anyRemaining = quizStatus.some(quiz => !quiz.solved);
+
+    if (anyRemaining) {
+      return (
+        <p className={styles.quizMentNormal}>
+          오늘 <span className={styles.bold7}>{quizStatus.filter(q => !q.solved).length}</span>개의
+          퀴즈가 남았어요!
+          <br />
+          오늘의 퀴즈를 완료해봐요 :)
+        </p>
+      );
+    } else if (allSolved) {
+      return (
+        <p className={styles.quizMentNormal}>
+          오늘의 퀴즈는 종료되었지만
+          <br />
+          <span className={styles.bold7}>오늘의 퀴즈 해설</span>을 볼 수 있어요.
+          <br />
+          ‘해설 보기’를 눌러보세요!
+        </p>
+      );
+    } else {
       return (
         <>
           <p className={styles.quizMentNormal}>
@@ -41,24 +114,6 @@ export default function QuizMain() {
             정답 하나 당 <span className={styles.boldGreen}>100포인트</span>를 획득할 수 있어요!
           </p>
         </>
-      );
-    } else if (quizStatus.quiz1 && quizStatus.quiz2) {
-      return (
-        <p className={styles.quizMentNormal}>
-          오늘의 퀴즈는 종료되었지만
-          <br />
-          <span className={styles.bold7}>오늘의 퀴즈 해설</span>을 볼 수 있어요
-          <br />
-          ‘해설 보기’를 눌러보세요!
-        </p>
-      );
-    } else {
-      return (
-        <p className={styles.quizMentNormal}>
-          오늘 <span className={styles.bold7}>1개</span>의 퀴즈가 남았어요!
-          <br />
-          오늘의 퀴즈를 완료해봐요 :)
-        </p>
       );
     }
   };
@@ -73,14 +128,14 @@ export default function QuizMain() {
           <div className={styles.quizContainer}>
             {/* 첫 번째 */}
             <div
-              className={quizStatus.quiz1 ? styles.quizBtnClose : styles.quizBtnOpen}
-              onClick={() => !quizStatus.quiz1 && handleQuizClick(1)}
+              className={isQuizSolved(1) ? styles.quizBtnClose : styles.quizBtnOpen}
+              onClick={() => !isQuizSolved(1) && handleQuizClick(1)}
             >
               <div className={styles.quizBtnLeft}>
                 <IconPower className={styles.iconPower} />
                 <p className={styles.quizNormal}>첫 번째 퀴즈</p>
               </div>
-              {quizStatus.quiz1 ? (
+              {isQuizSolved(1) ? (
                 <button className={styles.expBtn} onClick={() => openPopup(1)}>
                   해설보기
                 </button>
@@ -91,14 +146,14 @@ export default function QuizMain() {
 
             {/* 두 번째 */}
             <div
-              className={quizStatus.quiz2 ? styles.quizBtnClose : styles.quizBtnOpen}
-              onClick={() => !quizStatus.quiz2 && handleQuizClick(2)}
+              className={isQuizSolved(2) ? styles.quizBtnClose : styles.quizBtnOpen}
+              onClick={() => !isQuizSolved(2) && handleQuizClick(2)}
             >
               <div className={styles.quizBtnLeft}>
                 <IconPower className={styles.iconPower} />
                 <p className={styles.quizNormal}>두 번째 퀴즈</p>
               </div>
-              {quizStatus.quiz2 ? (
+              {isQuizSolved(2) ? (
                 <button className={styles.expBtn} onClick={() => openPopup(2)}>
                   해설보기
                 </button>
@@ -112,7 +167,13 @@ export default function QuizMain() {
         </div>
       </Box>
 
-      {isPopupOpen && <Popup questionId={currentQuestionId} onClose={closePopup} />}
+      {isPopupOpen && currentQuestionId !== null && (
+        <Popup
+          quizData={quizStatus.find(quiz => quiz.questionId === currentQuestionId) as QuizData}
+          questionId={currentQuestionId}
+          onClose={closePopup}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/_component/quiz/QuizSubmit.module.css
+++ b/src/app/_component/quiz/QuizSubmit.module.css
@@ -36,6 +36,7 @@
   background: #f1f3f5;
   display: flex;
   align-items: center;
+  cursor: pointer;
 }
 
 .answerBtnClick {
@@ -47,6 +48,7 @@
   background: #d7f3c6;
   display: flex;
   align-items: center;
+  cursor: pointer;
 }
 
 .answerContainer {

--- a/src/app/_component/quiz/QuizSubmit.tsx
+++ b/src/app/_component/quiz/QuizSubmit.tsx
@@ -1,48 +1,110 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import axios from "axios";
 import Box from "@/components/Box";
 import styles from "./QuizSubmit.module.css";
 import IconMent from "@/../public/icon/quiz_ment.svg";
 import IconChoice from "@/../public/icon/quiz_check.svg";
 import IconChoiceClick from "@/../public/icon/quiz_check_active.svg";
+import { useQuizContext } from "@/context/QuizContext";
+import { apiWrapper } from "@/utils/api";
 
 interface QuizSubmitProps {
-  id: string;
+  questionId: number;
+  quizId: number;
 }
 
-export default function QuizSubmit({ id }: QuizSubmitProps) {
+export default function QuizSubmit({ questionId, quizId }: QuizSubmitProps) {
   const router = useRouter();
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
+  const [quizData, setQuizData] = useState<any>(null);
+
+  const { setQuizData: setQuizContext } = useQuizContext();
+
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+  useEffect(() => {
+    const fetchQuizData = async () => {
+      try {
+        const response = await axios.get(`${API_URL}/quiz/${quizId}`);
+        if (response.data.success) {
+          setQuizData(response.data.data);
+        } else {
+          console.error("API 호출 실패:", response.data.message);
+        }
+      } catch (error) {
+        console.error("API 호출 중 오류 발생:", error);
+      }
+    };
+
+    fetchQuizData();
+  }, [quizId]);
 
   const handleAnswerClick = (index: number) => {
     setSelectedAnswer(index);
   };
 
-  const handleAnswerSubmit = () => {
-    if (selectedAnswer !== null) {
-      router.push(`/quiz/${id}/answer/`);
-    }
+  const handleAnswerSubmit = async () => {
+    return apiWrapper(async () => {
+      if (selectedAnswer !== null) {
+        console.log(quizId, quizData[`choice${selectedAnswer + 1}`]);
+        try {
+          const response = await axios.post(
+            `${API_URL}/submit`,
+            {},
+            {
+              withCredentials: true,
+              params: { quizId, userAnswer: quizData[`choice${selectedAnswer + 1}`] }
+            }
+          );
+
+          const { data } = response;
+          if (data.success) {
+            console.log("서버 응답 데이터:", data);
+
+            setQuizContext({
+              question: data.data.question,
+              userAnswer: data.data.userAnswer,
+              correctAnswer: data.data.correctAnswer,
+              explanation: data.data.explanation,
+              isCorrect: data.data.correct ? "true" : "false"
+            });
+
+            console.log("퀴즈 컨텍스트에 설정된 데이터:", {
+              question: data.data.question,
+              userAnswer: data.data.userAnswer,
+              correctAnswer: data.data.correctAnswer,
+              explanation: data.data.explanation,
+              isCorrect: data.data.correct ? "true" : "false"
+            });
+            router.push(`/quiz/${questionId}/answer`);
+          } else {
+            console.error("제출 실패:", data.message);
+          }
+        } catch (error) {
+          console.error("API 호출 중 오류 발생:", error);
+        }
+      }
+    }, API_URL);
   };
 
+  if (!quizData) {
+    return <p>Loading...</p>;
+  }
+
+  const answers = [quizData.choice1, quizData.choice2, quizData.choice3, quizData.choice4];
   return (
     <div className={styles.boxContainer}>
       <Box minHeight="330px">
         <div className={styles.iconMentContainer}>
           <IconMent style={{ width: "3.2rem", height: "2.4rem" }} />
-          <p>Q{id}</p>
+          <p>Q{questionId}</p>
         </div>
         <div className={styles.quizBoxContainer}>
-          <p className={styles.quizTitle}>
-            가정에서 에너지를 절약하기 위한 올바른 방법은 무엇인가요?
-          </p>
+          <p className={styles.quizTitle}>{quizData.question}</p>
           <div className={styles.answerContainer}>
-            {[
-              "에어컨을 밤새 켜두기",
-              "전등을 LED로 교체하기",
-              "냉장고 문을 자주 열기",
-              "사용하지 않는 전자기기를 플러그에 꽂아두기"
-            ].map((answer, index) => (
+            {answers.map((answer, index) => (
               <div
                 key={index}
                 className={selectedAnswer === index ? styles.answerBtnClick : styles.answerBtn}

--- a/src/context/QuizContext.tsx
+++ b/src/context/QuizContext.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+
+interface QuizDataType {
+  question: string;
+  userAnswer: string;
+  correctAnswer: string;
+  explanation: string;
+  isCorrect: string;
+}
+
+interface QuizContextType extends QuizDataType {
+  setQuizData: (data: QuizDataType) => void;
+}
+
+const QuizContext = createContext<QuizContextType | undefined>(undefined);
+
+export const useQuizContext = () => {
+  const context = useContext(QuizContext);
+  if (!context) {
+    throw new Error("QuizContext를 찾을 수 없습니다.");
+  }
+  return context;
+};
+
+interface QuizProviderProps {
+  children: ReactNode;
+}
+
+export const QuizProvider = ({ children }: QuizProviderProps) => {
+  const [quizData, setQuizData] = useState<QuizDataType>({
+    question: "",
+    userAnswer: "",
+    correctAnswer: "",
+    explanation: "",
+    isCorrect: ""
+  });
+
+  useEffect(() => {
+    console.log("QuizProvider State:", quizData);
+  }, [quizData]);
+
+  return (
+    <QuizContext.Provider value={{ ...quizData, setQuizData }}>{children}</QuizContext.Provider>
+  );
+};


### PR DESCRIPTION
## 📝 PR 유형
- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
<!-- ex) close #1 -->
#94 
## ✅ 작업 목록
<!-- 이슈 작업한 내용 -->
1. 퀴즈 api 연결(+포인트 갱신)

## 🍰 논의사항
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->
### context
- `QuizSubmit.tsx `에서 정답 제출 api를 통해 받아온 데이터(문제, 고른 답, 정답, 해설, 정답 여부)를 `QuizAnswer.tsx`로 넘겨야 하는 상황
- `context`를 사용해 전역으로 데이터를 관리하기로 함`(quizSubmit -> quizContext -> quizAnswer)`
- `quizSubmit`, `quizAnswer`에서만 사용하는 데이터라서 해당 컴포넌트를 사용하는 페이지에서만 불러옴
```
import { QuizProvider } from "@/context/QuizContext";

export default function Page() {
return (
    <>
      <QuizProvider>
        <QuizAnswer/>
      </QuizProvider>
    </>
  );
```
-> `submit`에서는 `context`로 데이터가 잘 보내지고 `context`에서 데이터가 잘 읽혀짐! 그러나 `answer`로 이동하면서 데이터가 없어짐(콘솔 확인)
-> 이유 : 페이지가 바뀌기 때문에 데이터가 새로고침되면서 `context`파일에 디폴드값으로 넣어둔 `null`을 받게 됨

**해결!!**
```
"use client";

import TopBar from "@/components/TopBar";
import { QuizProvider } from "@/context/QuizContext";

export default function Layout({
  children
}: Readonly<{
  children: React.ReactNode;
}>) {
  return (
    <>
      <QuizProvider>
        <TopBar text={"에너지 퀴즈"} />
        {children}
      </QuizProvider>
    </>
  );
}

```
**-> 퀴즈 레이아웃에서 provider로 감쌌더니 쉽게 해결..!😹**

💯 전역 데이터를 특정 페이지에서만 사용한다고 해당 페이지들만 감싸는 것이 아니라 루트 레이아웃에서 `{children}`을 감싸야한다!
## 📷 ETC
<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->

https://github.com/user-attachments/assets/d74b5db8-0d93-4664-8a2e-f380875144b4

![스크린샷 2024-12-07 15 29 51](https://github.com/user-attachments/assets/fb3222d2-152c-41d3-ac41-da95456ca08a)
-> 정답 시 포인트 갱신 확인!
