### PR TITLE
Feat: 에너지 효율 등급에 따른 디자인 변경

### DIFF
--- a/src/app/(common-layout)/list/appliances/[id]/page.module.css
+++ b/src/app/(common-layout)/list/appliances/[id]/page.module.css
@@ -9,13 +9,31 @@
   margin-top: 1.2rem;
 }
 
+.Box {
+  width: 340px;
+  min-height: 400px;
+  padding: 0.3em;
+
+  background-color: #ffffff;
+  border-radius: 1.5em;
+  box-shadow: 0em 0.1em 0.8em 0em #d7f3c6;
+
+  background-image: linear-gradient(#fff, #fff), linear-gradient(#D7F3C6 0%, #91E26B 50%, #D7F3C6 100%);
+  background-origin: border-box;
+  background-clip: content-box, border-box;
+}
+
+.BoxPadding {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 1.6em 1.2em;
+}
 .ViewWrapper {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
   padding: 1rem;
-  min-height: 400px;
 }
 
 .BtnWrapper {
@@ -68,4 +86,22 @@
 .margin {
   width: 10rem;
   height: 10rem;
+}
+
+.changeGradeWrapper {
+  width: 28.9rem;
+  margin-bottom: 2.9rem;
+  padding: 0.6rem 0.8rem;
+
+  border-radius: 20px;
+  background: #f1f3f5;
+
+  color: #5e5e5e;
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  letter-spacing: 0.14px;
 }

--- a/src/app/(common-layout)/list/appliances/[id]/page.module.css
+++ b/src/app/(common-layout)/list/appliances/[id]/page.module.css
@@ -18,7 +18,6 @@
   border-radius: 1.5em;
   box-shadow: 0em 0.1em 0.8em 0em #d7f3c6;
 
-  background-image: linear-gradient(#fff, #fff), linear-gradient(#D7F3C6 0%, #91E26B 50%, #D7F3C6 100%);
   background-origin: border-box;
   background-clip: content-box, border-box;
 }

--- a/src/app/(common-layout)/list/appliances/[id]/page.tsx
+++ b/src/app/(common-layout)/list/appliances/[id]/page.tsx
@@ -50,6 +50,7 @@ export default function AppliancePage({ params }: { params: { id: string | strin
 
         const mappedDetails = mapApplianceDetails(transformedItem, applianceType);
         setApplianceDetails(mappedDetails);
+        console.log(mappedDetails);
 
         const memoContent = memoData[0]?.content || null;
         setMemo(memoContent);
@@ -85,21 +86,26 @@ export default function AppliancePage({ params }: { params: { id: string | strin
 
   return (
     <div className={style.BoxWrapper}>
-      <Box minHeight="400px">
-        <div className={style.ViewWrapper}>
-          <TopView {...applianceDetails} />
-          <BottomView {...applianceDetails} />
+      <div className={style.Box}>
+        <div className={style.BoxPadding}>
+          <div className={style.ViewWrapper}>
+            <div
+              className={style.changeGradeWrapper}
+            >{`에너지효율등급이 3 → 1 등급으로 변경되었어요!`}</div>
+            <TopView {...applianceDetails} />
+            <BottomView {...applianceDetails} />
+          </div>
+          {memo ? <div className={style.memoTitle}>메모</div> : ""}
+          <div className={style.memoSection}>
+            {memo ? <div className={style.memoItem}>{memo}</div> : ""}
+          </div>
+          <div className={style.BtnWrapper}>
+            <DeleteBtn applianceId={params.id} />
+            <MemoBtn applianceId={params.id} hasMemo={hasMemo} onMemoAdded={handleMemoAdded} />
+          </div>
         </div>
-        {memo ? <div className={style.memoTitle}>메모</div> : ""}
-        <div className={style.memoSection}>
-          {memo ? <div className={style.memoItem}>{memo}</div> : ""}
-        </div>
-        <div className={style.BtnWrapper}>
-          <DeleteBtn applianceId={params.id} />
-          <MemoBtn applianceId={params.id} hasMemo={hasMemo} onMemoAdded={handleMemoAdded} />
-        </div>
-      </Box>
-      <div className={style.margin}/>
+      </div>
+      <div className={style.margin} />
     </div>
   );
 }

--- a/src/app/(common-layout)/list/appliances/[id]/page.tsx
+++ b/src/app/(common-layout)/list/appliances/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import axios from "axios";
-import Box from "@/components/Box";
 import { mapApplianceDetails } from "@/utils/renderApplianceDetails";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import style from "./page.module.css";
@@ -12,6 +11,7 @@ import LoadingDots from "@/components/LoadingDots";
 import DeleteBtn from "@/app/_component/appliances/[id]/DeleteBtn";
 import { apiWrapper } from "@/utils/api";
 import MemoBtn from "@/app/_component/appliances/[id]/MemoBtn";
+import { getGradientFromGrade } from "@/utils/getColorfromGrade"; // 이 부분 추가
 
 export default function AppliancePage({ params }: { params: { id: string | string[] } }) {
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -84,14 +84,23 @@ export default function AppliancePage({ params }: { params: { id: string | strin
     );
   if (!applianceDetails) return <p>No data available</p>;
 
+  const gradient = getGradientFromGrade(applianceDetails.효율등급);
+
   return (
     <div className={style.BoxWrapper}>
-      <div className={style.Box}>
+      <div
+        className={style.Box}
+        style={{
+          backgroundImage: gradient
+            ? `linear-gradient(#fff, #fff), linear-gradient(${gradient.first} 0%, ${gradient.second} 50%, ${gradient.third} 100%)`
+            : "none"
+        }}
+      >
         <div className={style.BoxPadding}>
           <div className={style.ViewWrapper}>
             <div
               className={style.changeGradeWrapper}
-            >{`에너지효율등급이 3 → 1 등급으로 변경되었어요!`}</div>
+            >{`에너지효율등급이 3 → ${applianceDetails.효율등급} 등급으로 변경되었어요!`}</div>
             <TopView {...applianceDetails} />
             <BottomView {...applianceDetails} />
           </div>

--- a/src/app/_component/appliances/MyAppliances.module.css
+++ b/src/app/_component/appliances/MyAppliances.module.css
@@ -51,3 +51,37 @@
 .lastLabel {
   visibility: hidden;
 }
+
+.alarm {
+  position: absolute;
+  top: 0.3em;
+  right: -0.2em;
+
+  min-width: 1.6em;
+  min-height: 1.6em;
+  max-width: 1.6em;
+  max-height: 1.6em;
+
+  border-radius: 50%;
+  border: 0.2em solid #fff;
+  background-color: #19e407;
+  box-sizing: border-box;
+}
+
+.lastAlarm {
+  visibility: hidden;
+
+  position: absolute;
+  top: -0.3em;
+  right: -0.2em;
+
+  min-width: 1.6em;
+  min-height: 1.6em;
+  max-width: 1.6em;
+  max-height: 1.6em;
+
+  border-radius: 50%;
+  border: 0.2em solid #fff;
+  background-color: #19e407;
+  box-sizing: border-box;
+}

--- a/src/app/_component/appliances/MyAppliances.module.css
+++ b/src/app/_component/appliances/MyAppliances.module.css
@@ -26,22 +26,19 @@
   position: relative;
 }
 
-.LinkContainer:last-child::after {
-  content: "";
-  display: block;
-  width: 100%;
-  height: 12px;
-}
-
 .AddCircle {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 69px;
-  height: 69px;
-  border-radius: 50%;
-  background-color: #d7f3c6;
+
+  width: 6.9rem;
+  height: 6.9rem;
+  max-height: 6.9rem;
+  min-height: 6.9rem;
+  border-radius: 200%;
   box-sizing: border-box;
+
+  background-color: #d7f3c6;
 }
 
 .LoadingWrapper {
@@ -49,4 +46,8 @@
   justify-content: center;
   align-items: center;
   height: 600px;
+}
+
+.lastLabel {
+  visibility: hidden;
 }

--- a/src/app/_component/appliances/MyAppliances.tsx
+++ b/src/app/_component/appliances/MyAppliances.tsx
@@ -68,6 +68,7 @@ export default function MyAppliances() {
           {data.map(item => (
             <Link href={`list/appliances/${item.applianceId}`} key={item.applianceId}>
               <div className={style.LinkContainer}>
+                <div className={style.alarm}></div>
                 <Appliance id={item.applianceId} grade={item.grade} type={item.matchTerm} />
                 <GradeLabel grade={item.grade} />
               </div>
@@ -75,6 +76,7 @@ export default function MyAppliances() {
           ))}
           <Link href={`list/appliances/add`}>
             <div className={style.LinkContainer}>
+              <div className={style.lastAlarm}></div>
               <div className={style.AddCircle}>
                 <IconPlus width={"2.4rem"} height={"2.4rem"} />
               </div>

--- a/src/app/_component/appliances/MyAppliances.tsx
+++ b/src/app/_component/appliances/MyAppliances.tsx
@@ -15,7 +15,7 @@ interface ApplianceData {
   applianceId: number;
   grade: string;
   matchTerm: string;
-  updated?: boolean;
+  updated: boolean;
 }
 
 export default function MyAppliances() {
@@ -68,7 +68,11 @@ export default function MyAppliances() {
           {data.map(item => (
             <Link href={`list/appliances/${item.applianceId}`} key={item.applianceId}>
               <div className={style.LinkContainer}>
-                <div className={style.alarm}></div>
+                {item.updated ? (
+                  <div className={style.alarm}></div>
+                ) : (
+                  <div className={style.lastAlarm}></div>
+                )}
                 <Appliance id={item.applianceId} grade={item.grade} type={item.matchTerm} />
                 <GradeLabel grade={item.grade} />
               </div>

--- a/src/app/_component/appliances/MyAppliances.tsx
+++ b/src/app/_component/appliances/MyAppliances.tsx
@@ -78,6 +78,9 @@ export default function MyAppliances() {
               <div className={style.AddCircle}>
                 <IconPlus width={"2.4rem"} height={"2.4rem"} />
               </div>
+              <div className={style.lastLabel}>
+                <GradeLabel grade={""} />
+              </div>
             </div>
           </Link>
         </div>

--- a/src/app/_component/appliances/[id]/BottomView.module.css
+++ b/src/app/_component/appliances/[id]/BottomView.module.css
@@ -5,7 +5,7 @@
   justify-content: center;
   align-items: center;
 
-  margin-top: 4.2em;
+  margin-bottom: 4.2em;
 }
 
 .itemWrapper {

--- a/src/app/_component/appliances/[id]/TopView.module.css
+++ b/src/app/_component/appliances/[id]/TopView.module.css
@@ -2,6 +2,8 @@
   display: flex;
   align-items: center;
   gap: 2.7em;
+
+  margin-bottom: 4.2em;
 }
 
 .Circle {

--- a/src/utils/getColorfromGrade.ts
+++ b/src/utils/getColorfromGrade.ts
@@ -15,3 +15,41 @@ export const getColorFromGrade = (grade: string): string => {
       return "#83c63f";
   }
 };
+
+// 등급(숫자)을 받으면 그라데이션 색 3개를 반환해주는 함수
+export const getGradientFromGrade = (
+  grade: string
+): { first: string; second: string; third: string } | undefined => {
+  switch (grade) {
+    case "1":
+      return {
+        first: "#D7F3C6",
+        second: "#91E26B",
+        third: "#D7F3C6"
+      };
+    case "2":
+      return {
+        first: "#ECF0B9",
+        second: "#D6E04C",
+        third: "#ECF0B9"
+      };
+    case "3":
+      return {
+        first: "#FFFCCC",
+        second: "#FEF100",
+        third: "#FFFCCC"
+      };
+    case "4":
+      return {
+        first: "#FDE8CB",
+        second: "#F9A734",
+        third: "#FDE8CB"
+      };
+    case "5":
+      return {
+        first: "#F8CAC7",
+        second: "#ED3125",
+        third: "#F8CAC7"
+      };
+  }
+};


### PR DESCRIPTION
## 📝 PR 유형
- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #104

## ✅ 작업 목록
- 에너지 효율 등급 변경 시 가전 페이지 초록색 아이콘
- 가전 추가 페이지 + 밀림 CSS 해결
- 에너지 효율 등급 변경 시 상세 페이지

## 🍰 논의사항
### 추가 아이콘 밀림 현상

추가 Circle div 아래에

```
.lastLabel {
  visibility: hidden;
}

```
클래스 이름으로 추가하여 빈 div로 감싸준 뒤 위의 visibility 속성으로 숨겼습니다. (크기는 차지하되, 보이지는 않는 상태)

사실 밑에 “등급” 이라는 표시가 있지만, 보이지는 않는 상태로 해결했는데 더 좋은 방법 있으시면 말씀해주시면 감사하겠습니다!

### 히스토리 페이지와 상세 페이지에서 가전제품 이미지 원 색 바뀌는 작업은 다음 이슈에서 작업 예정입니다.
<img width="185" alt="image" src="https://github.com/user-attachments/assets/fa10c952-a945-4549-a755-59fc6098f68e">
원 색 바뀌는 작업은 위 사진 참고 부탁드립니다.


## 📷 ETC
### 업데이트가 true라면 가전제품 리스트 페이지
<img width="348" alt="스크린샷 2024-12-09 오후 5 55 34" src="https://github.com/user-attachments/assets/1a703cdb-6a60-463f-b1b1-b926d4c499fa">

### 업데이트 true라면 가전제품 상세 페이지
<img width="350" alt="스크린샷 2024-12-09 오후 8 17 57" src="https://github.com/user-attachments/assets/4ec42851-2fea-4f70-b7f8-8dfc61f2cf7b">

### 업데이트 되었을 경우 border 그라데이션

https://github.com/user-attachments/assets/edbce803-c486-4564-a4b2-092a960dea64

### history 호출 성공 시
![image](https://github.com/user-attachments/assets/ea87ae22-3c9f-4f89-a404-c58f0396a9ff)
지금은 변경이 안 되어서 저렇게 오지만, 변경이 되면 바뀐 모든 제품이 배열로 와 applianceId가 같은 것을 찾아 해당 제품의 기존 효율등급을 가져와 렌더링 하는 로직입니다.
