### PR TITLE
Feat: 4차 QA (1)

### DIFF
--- a/src/app/(common-layout)/book/page.module.css
+++ b/src/app/(common-layout)/book/page.module.css
@@ -41,7 +41,8 @@
 /* card */
 .card {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 3em;
 }
 
 .rightSection {

--- a/src/app/(common-layout)/list/appliances/[id]/page.module.css
+++ b/src/app/(common-layout)/list/appliances/[id]/page.module.css
@@ -46,7 +46,6 @@
 .memoSection {
   width: 100%;
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
 }
@@ -59,12 +58,9 @@
 }
 
 .memoItem {
-  display: flex;
-  align-items: center;
-  padding: 0 1.4em;
+  padding: 1em 1.4em;
   margin-bottom: 2.4em;
-  width: 80%;
-  min-height: 4.1em;
+  width: 27rem;
   border-radius: 10px;
   background: #f1f3f5;
 
@@ -73,6 +69,8 @@
   font-style: normal;
   font-weight: 500;
   line-height: normal;
+  overflow-wrap: break-word;
+  line-height: 200%;
 }
 
 .noMemos {

--- a/src/app/_component/appliances/AddButton.tsx
+++ b/src/app/_component/appliances/AddButton.tsx
@@ -9,14 +9,16 @@ interface AddButtonProps {
 export default function AddButton({ handleAdd, selectedIndex }: AddButtonProps) {
   return (
     <div className={styles.buttonWrapper}>
-      <ToolTip/>
-      <button
-        onClick={handleAdd}
-        className={`${styles.addButton} ${selectedIndex !== null ? styles.activeButton : ""}`}
-        disabled={selectedIndex === null}
-      >
-        추가하기
-      </button>
+      <div className={styles.addBtnWrapper}>
+        <ToolTip />
+        <button
+          onClick={handleAdd}
+          className={`${styles.addButton} ${selectedIndex !== null ? styles.activeButton : ""}`}
+          disabled={selectedIndex === null}
+        >
+          추가하기
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/app/_component/appliances/ClientComponent.module.css
+++ b/src/app/_component/appliances/ClientComponent.module.css
@@ -126,12 +126,28 @@
   height: 70px;
 }
 
+.addBtnWrapper {
+  position: fixed;
+  bottom: 115px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
+  background-color: rgba(255, 255, 255, 0.917);
+  border-radius: 10px;
+  z-index: 10;
+  box-shadow: 0 0 20px #d7f3c687;
+  font-family: var(--font-pretendard);
+}
+
 .addButton {
   width: 27.7rem;
   height: 3.8rem;
   border: none;
   border-radius: 15px;
   background-color: #c4c4c4;
+  font-family: var(--font-pretendard);
   color: #fff;
   font-size: 1.6rem;
   font-style: normal;

--- a/src/app/_component/appliances/ToolTip.module.css
+++ b/src/app/_component/appliances/ToolTip.module.css
@@ -84,6 +84,7 @@
   border-radius: 10px;
   box-shadow: 0px 0px 8px #d4ddcf;
 
+  font-family: var(--font-pretendard);
   color: #000;
   font-size: 1rem;
   font-style: normal;

--- a/src/app/_component/appliances/ToolTip.module.css
+++ b/src/app/_component/appliances/ToolTip.module.css
@@ -12,7 +12,7 @@
 
   margin-bottom: 1em;
 
-  z-index: 1002;
+  z-index: 10;
 }
 
 .btnContainer {
@@ -50,7 +50,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1001;
+  z-index: 9;
 
   width: 100%;
   height: 100%;

--- a/src/app/_component/home/AttendanceCoin.module.css
+++ b/src/app/_component/home/AttendanceCoin.module.css
@@ -9,6 +9,7 @@
 
   overflow: visible;
   cursor: pointer;
+  font-family: var(--font-pretendard);
 }
 
 .coinWrap {

--- a/src/app/_component/home/attendanceModal.tsx/AttendanceModal.module.css
+++ b/src/app/_component/home/attendanceModal.tsx/AttendanceModal.module.css
@@ -15,6 +15,7 @@
 }
 
 .popupWrapper {
+  font-family: var(--font-pretendard);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -122,6 +123,7 @@
   font-style: normal;
   font-weight: 600;
   line-height: normal;
+  font-family: var(--font-pretendard);
 
   cursor: pointer;
 }

--- a/src/app/_component/home/attendanceModal.tsx/AttendanceModal.tsx
+++ b/src/app/_component/home/attendanceModal.tsx/AttendanceModal.tsx
@@ -1,6 +1,9 @@
+"use client";
 import Image from "next/image";
 import styles from "./AttendanceModal.module.css";
 import PointIcon from "@/../public/icon/point_symbol.svg";
+import { useEffect, useState } from "react";
+import axios from "axios";
 
 interface AttendanceModalProps {
   click: boolean;
@@ -8,11 +11,35 @@ interface AttendanceModalProps {
 }
 
 export default function AttendanceModal({ click, onClick }: AttendanceModalProps) {
-  if (click) {
-    document.body.style.overflow = "hidden";
-  } else {
-    document.body.style.overflow = "auto";
-  }
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const [point, setPoint] = useState(0);
+
+  useEffect(() => {
+    if (click) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "auto";
+    }
+
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, [click]);
+
+  useEffect(() => {
+    const fetchPoint = async () => {
+      try {
+        const res = await axios.get(`${API_URL}/point`, { withCredentials: true });
+        if (res.data.success === true) {
+          setPoint(res.data.data);
+        }
+      } catch (error) {
+        console.log("오류 발생:", error);
+      }
+    };
+    fetchPoint();
+  }, [click]);
+
   return (
     <div className={styles.popupWrapper}>
       <div className={styles.popup}>
@@ -28,7 +55,7 @@ export default function AttendanceModal({ click, onClick }: AttendanceModalProps
         </div>
         <div className={styles.confirmWrapper}>
           <div className={styles.currentPoint}>
-            현재 <span className={styles.textBold}>1450</span> <PointIcon />
+            현재 <span className={styles.textBold}>{point}</span> <PointIcon />
           </div>
           <button className={styles.confirmBtn} onClick={onClick}>
             확인

--- a/src/components/HomeBtn.module.css
+++ b/src/components/HomeBtn.module.css
@@ -12,6 +12,7 @@
   border-radius: 15px;
   font-size: 1.6rem;
   font-weight: 600;
+  font-family: var(--font-pretendard);
 }
 
 .homeButton:hover {

--- a/src/components/Toast.module.css
+++ b/src/components/Toast.module.css
@@ -34,6 +34,8 @@
   border-radius: 1.5em;
 
   background: rgba(94, 94, 94, 0.85);
+
+  font-family: var(--font-pretendard);
   color: #fff;
   font-size: 1.4rem;
   font-style: normal;

--- a/src/components/TopBar.module.css
+++ b/src/components/TopBar.module.css
@@ -7,6 +7,7 @@
   height: 62px;
   background-color: #f8fff3;
 
+  font-family: var(--font-pretendard);
   font-size: 16px;
   font-style: normal;
   font-weight: 600;

--- a/src/components/TopBarAppliance.module.css
+++ b/src/components/TopBarAppliance.module.css
@@ -7,6 +7,7 @@
   height: 62px;
   background-color: #f8fff3;
 
+  font-family: var(--font-pretendard);
   font-size: 16px;
   font-style: normal;
   font-weight: 600;

--- a/src/components/bottomNav.module.css
+++ b/src/components/bottomNav.module.css
@@ -34,7 +34,7 @@
   position: relative;
   top: -1.5rem;
   width: 2rem;
-
+  font-family: var(--font-pretendard);
   font-size: 1rem;
   font-weight: 500;
   text-align: center;


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [x] ETC: 디자인 이슈

## 🔔 관련된 이슈 넘버
close #124

## ✅ 작업 목록
백과 페이지 - 에너지 백과 세션 가운데 정렬
가전제품 리스트 페이지 - 가전제품 메모 기능에서, 50자를 꽉 채워서 입력 시 칸 넘어감 CSS
가전제품 추가 페이지 - 추가하기 버튼 하단에 고정
가전제품 추가 페이지 - 툴팁 z-index 수정
홈 - 출석체크시 뜨는 모달 유저 현재 포인트로 변경
기타 - 폰트 적용 안 되는 컴포넌트 일단은 ```font-family: var(--font-pretendard); ```로 추가해놨습니다. 맥북 기본 폰트로 보이는 게 있는 것 같아서!

## 🍰 논의사항
가전제품 추가 버튼 하단에 고정 이슈에서 바텀바가 이미 고정이고 박스가 유동적으로 변하는 사이즈라 디자인도 애매해서 일단은 이렇게 추가했습니다.

https://github.com/user-attachments/assets/4d3180bf-2c36-447d-8302-69ecf1c278c8

