### PR TITLE
Fix/4 qa 1

### DIFF
--- a/src/app/_component/home/HomeEncyclopedia.tsx
+++ b/src/app/_component/home/HomeEncyclopedia.tsx
@@ -17,10 +17,7 @@ export default function HomeEncyclopedia() {
         <Box>
           <div className={styles.bodyContainer}>
             <p className={styles.text_title}>에너지 절약 팁을 제공해드려요!</p>
-            <p className={styles.text_normal}>
-              오늘은 <span className={styles.appliancsGreen}>에어컨 </span>절약 팁에 대해
-              알아볼까요?
-            </p>
+            <p className={styles.text_normal}>쉽고 간단한 에너지 절약 방법, 함께 알아볼까요?</p>
           </div>
           <button type="button" className={styles.btn} onClick={handleNavigate}>
             보러가기

--- a/src/app/_component/home/HomeQuiz.tsx
+++ b/src/app/_component/home/HomeQuiz.tsx
@@ -18,9 +18,7 @@ export default function HomeQuiz() {
           <div className={styles.bodyContainer}>
             <p className={styles.text_title}>하루에 두 번 찾아오는 기회!</p>
             <p className={styles.text_normal}>
-              매일 <span className={styles.quizBold}>오전 7시</span>,
-              <span className={styles.quizBold}>오후 6시</span>에{" "}
-              <span className={styles.quizBold}>2시간</span>씩 오픈되는
+              매일 <span className={styles.quizBold}>2개씩</span> 오픈되는
               <br />
               오늘의 에너지 퀴즈를 풀어보세요.
               <br />

--- a/src/app/_component/my/ResetPopup.tsx
+++ b/src/app/_component/my/ResetPopup.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import axios from "axios";
 import styles from "./ResetPopup.module.css";
 import IconWarn from "@/../public/icon/warning.svg";
+import Toast from "@/components/Toast";
 
 interface ResetPopupProps {
   onClose: () => void;
@@ -12,7 +13,7 @@ type PopupType = "main" | "email" | "noPoints";
 const ResetPopup: React.FC<ResetPopupProps> = ({ onClose }) => {
   const [currentPopup, setCurrentPopup] = useState<PopupType>("main");
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [toastMessage, setToastMessage] = useState<string>("");
 
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -29,15 +30,14 @@ const ResetPopup: React.FC<ResetPopupProps> = ({ onClose }) => {
       });
 
       if (response.data && response.data.success) {
-        console.log("초기화가 완료되었습니다.");
-        alert("초기화가 완료되었습니다."); // 모바일 테스트 후 수정
+        setToastMessage("초기화가 완료되었습니다.");
         closeAllPopups();
       } else {
-        setErrorMessage("초기화에 실패했습니다. 다시 시도해주세요.");
+        setToastMessage("초기화에 실패했습니다. 다시 시도해주세요.");
       }
     } catch (error) {
       console.error("API 요청 중 오류 발생:", error);
-      setErrorMessage("초기화 중 오류가 발생했습니다.");
+      setToastMessage("초기화 중 오류가 발생했습니다.");
     } finally {
       setIsSubmitting(false);
     }
@@ -52,7 +52,6 @@ const ResetPopup: React.FC<ResetPopupProps> = ({ onClose }) => {
               <IconWarn style={{ width: "5.1rem", height: "5.1rem" }} />
               <p className={styles.warningMent}>한 번 삭제된 데이터는 복구할 수 없습니다.</p>
               <p className={styles.resetMent}>초기화 하시겠어요?</p>
-              {errorMessage && <p className={styles.error}>{errorMessage}</p>}
               <div className={styles.btnContainer}>
                 <button className={styles.closeBtn} onClick={onClose} disabled={isSubmitting}>
                   취소하기
@@ -67,6 +66,7 @@ const ResetPopup: React.FC<ResetPopupProps> = ({ onClose }) => {
               </div>
             </div>
           </div>
+          {toastMessage && <Toast message={toastMessage} />}
         </div>
       )}
     </>

--- a/src/app/_component/power/ExpectPreChart.tsx
+++ b/src/app/_component/power/ExpectPreChart.tsx
@@ -263,7 +263,11 @@ const ExpectPreChart: React.FC<ExpectPreChartProps> = ({ member }) => {
       )
     },
     expect: {
-      noMonths: <>예상 요금을 입력해주세요!</>,
+      noMonths: (
+        <>
+          <p>파워를 입력하면 예상 요금을 알 수 있어요!</p>
+        </>
+      ),
       noPreMonth: (
         <>
           <p>
@@ -277,7 +281,7 @@ const ExpectPreChart: React.FC<ExpectPreChartProps> = ({ member }) => {
       ),
       noCurrentMonth: (
         <>
-          <p>파워를 입력하면 예상 요금을 알 수 있어요</p>
+          <p>파워를 입력하면 예상 요금을 알 수 있어요!</p>
         </>
       ),
 

--- a/src/app/_component/power/expectPreCost.module.css
+++ b/src/app/_component/power/expectPreCost.module.css
@@ -171,7 +171,7 @@
     height: 4rem;
   }
   to {
-    height: 4rem;
+    height: 5.2rem;
   }
 }
 

--- a/src/app/_component/powerinput/InputBottomSheet.tsx
+++ b/src/app/_component/powerinput/InputBottomSheet.tsx
@@ -116,7 +116,8 @@ const InputBottomSheet: React.FC<InputBottomSheetProps> = ({
             <div className={styles.bottomBar}></div>
             <div className={styles.sheetContent}>
               <p className={styles.sheetTitle}>
-                {name}님의 평균적인 전기요금과 차이가 커요! <br />
+                {name}님의 평균적인 전기요금과
+                <br /> 차이가 커요! <br />
                 정확히 입력했나요?
               </p>
               <div className={styles.btnContainer}>

--- a/src/app/_component/powerinput/InputBottomSheet.tsx
+++ b/src/app/_component/powerinput/InputBottomSheet.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import axios from "axios";
 import styles from "./InputBottomSheet.module.css";
 
 type InputBottomSheetProps = {
@@ -18,6 +19,7 @@ const InputBottomSheet: React.FC<InputBottomSheetProps> = ({
   const [currentY, setCurrentY] = useState(0);
   const [dragging, setDragging] = useState(false);
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const [name, setName] = useState<string>("사자");
 
   useEffect(() => {
     if (showBottomSheet) {
@@ -75,7 +77,26 @@ const InputBottomSheet: React.FC<InputBottomSheetProps> = ({
   const handleBottomSheetClick = (e: React.MouseEvent) => {
     e.stopPropagation();
   };
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await axios.get(`${API_URL}/users/my`, {
+          withCredentials: true
+        });
+        if (response.data && response.data.success) {
+          setName(response.data.data.name);
+        } else {
+          console.error("사용자 이름이 유효하지 않습니다.");
+        }
+      } catch (error) {
+        console.error("사용자 이름 가져오기 실패:", error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
   return (
     <>
       {showBottomSheet && (
@@ -95,7 +116,7 @@ const InputBottomSheet: React.FC<InputBottomSheetProps> = ({
             <div className={styles.bottomBar}></div>
             <div className={styles.sheetContent}>
               <p className={styles.sheetTitle}>
-                지난 달과 차이가 커요! <br />
+                {name}님의 평균적인 전기요금과 차이가 커요! <br />
                 정확히 입력했나요?
               </p>
               <div className={styles.btnContainer}>

--- a/src/app/_component/powerinput/PowerTable.module.css
+++ b/src/app/_component/powerinput/PowerTable.module.css
@@ -79,7 +79,7 @@
   width: 8rem;
 
   color: #929292 !important;
-  font-size: 10px !important;
+  font-size: 1rem !important;
 }
 
 .costUsageDivider {

--- a/src/app/_component/powerinput/PowerTable.tsx
+++ b/src/app/_component/powerinput/PowerTable.tsx
@@ -209,7 +209,7 @@ const PowerTable: React.FC = () => {
         id: "yearMonth"
       },
       {
-        Header: "전기요금",
+        Header: () => <div className={styles.yearHeader}>전기요금</div>,
         accessor: "cost",
         Cell: ({ row }: CellProps<TableRow>) => {
           const { year, month } = row.original;
@@ -231,7 +231,7 @@ const PowerTable: React.FC = () => {
         }
       },
       {
-        Header: "전력사용량",
+        Header: () => <div className={styles.yearHeader}>전력사용량</div>,
         accessor: "usage_amount",
         Cell: ({ row }: CellProps<TableRow>) => {
           const { year, month } = row.original;


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
<!-- ex) close #1 -->

## ✅ 작업 목록
<!-- 이슈 작업한 내용 -->
### <파워>
- 예상요금 차트 글씨 위치 수정(etc확인!)
- 예상요금 차트 멘트 수정
- 파워 입력 바텀시트 멘트 수정
- 입력 페이지 년도 헤더부분 어긋남 수정 
-> pc상에서는 전혀 어긋나지 않아서ㅠㅠ 배포 후 모바일에서 다시 확인해봐야 합니다..

### <홈>
- 퀴즈 및 백과 박스 멘트 수정

### <마이>
- 내정보수정 알림 토스트로 변경
- 
## 🍰 논의사항
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC
<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
<변경 전>
![스크린샷 2024-12-18 15 02 16](https://github.com/user-attachments/assets/64df7d7c-9784-4c2d-9921-d51b12ec8592)
<변경 후>
![스크린샷 2024-12-18 15 01 52](https://github.com/user-attachments/assets/85a23c00-ae56-41e1-b7f5-81cdcd9effd1)
-> ?,??? 일때의 높이가 `5.2rem`이었고 1분위는 `4rem`이었습니다. `5.2rem`에 맞춰 텍스트 위치를 고정하다보니 생긴 이슈였고
1분위도 `5.2rem`으로 수정했습니다! 비율 맞춰서 모든 분위 수정하려고 했으나 그럼 4분위는 `16rem` -> `20.8rem`이 돼서.. 너무 길어져서 1분위만 수정했습니다!
