### PR TITLE
Fix: 가전 리스트 페이지 박스 윗부분 잘림 이슈

### DIFF
--- a/src/app/(common-layout)/list/appliances/[id]/page.module.css
+++ b/src/app/(common-layout)/list/appliances/[id]/page.module.css
@@ -7,6 +7,8 @@
   background-color: #f8fff3;
   padding-bottom: 1rem;
   margin-top: 1.2rem;
+
+  font-family: var(--font-pretendard);
 }
 
 .Box {

--- a/src/app/_component/appliances/MyAppliances.module.css
+++ b/src/app/_component/appliances/MyAppliances.module.css
@@ -5,6 +5,8 @@
   width: 100%;
   background-color: #f8fff3;
   margin-bottom: 10rem;
+  margin-top: 0.6rem;
+  font-family: var(--font-pretendard);
 }
 
 .FlexLayout {

--- a/src/app/_component/appliances/[id]/DeleteBtn.module.css
+++ b/src/app/_component/appliances/[id]/DeleteBtn.module.css
@@ -14,6 +14,7 @@
   background: #b8c7b0;
   box-shadow: 0px 0px 0.4rem 0px #d4ddcf;
 
+  font-family: var(--font-pretendard);
   color: #fff;
   text-align: center;
   font-size: 1.2rem;

--- a/src/app/_component/appliances/[id]/MemoBtn.module.css
+++ b/src/app/_component/appliances/[id]/MemoBtn.module.css
@@ -7,6 +7,7 @@
   box-shadow: 0px 0px 4px 0px #d4ddcf;
   cursor: pointer;
 
+  font-family: var(--font-pretendard);
   color: #fff;
   text-align: center;
   font-size: 1.2rem;
@@ -62,6 +63,7 @@
   font-size: 1.2rem;
   line-height: 1.5;
   resize: none;
+  font-family: var(--font-pretendard);
 }
 
 .popupActions {
@@ -79,6 +81,7 @@
   background: #19e407;
   cursor: pointer;
 
+  font-family: var(--font-pretendard);
   color: #fff;
   text-align: center;
   font-size: 16px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import "@/styles/globals.css";
 import "@/styles/reset.css";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import StyledComponentsRegistry from "@/lib/registry";
 import localFont from "next/font/local";
 import ScrollReset from "@/components/ScrollReset";
@@ -26,7 +25,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="kr" className={`${pretendard.variable}`}>
-      <body className={`${pretendard.variable}`}>
+      <body className={`${pretendard.className}`}>
         <StyledComponentsRegistry>
           <ScrollReset />
           {children}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,7 +4,6 @@
   --html-background: #f8fff3;
   --vh: 100%;
   font-size: 62.5%;
-  font-family: var(--font-pretendard);
 }
 
 html,
@@ -26,7 +25,6 @@ html {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
   max-width: 375px;
   width: 100%;
   min-height: 100vh;
@@ -39,9 +37,17 @@ body {
   background: #a9a9a9;
 }
 
-@media (prefers-color-scheme: dark) {
+button {
+  font-family: var(--font-pretendard);
+}
+
+a {
+  text-decoration: none;;
+}
+
+/* @media (prefers-color-scheme: dark) {
   body {
     background-color: var(--background);
     color: var(--foreground);
   }
-}
+} */

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,3 +1,4 @@
+/* reset.css */
 html,
 body,
 div,
@@ -83,12 +84,41 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
   vertical-align: baseline;
 }
-
-a {
-  text-decoration: none;
-  color: inherit;
-  cursor: pointer;
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
 }


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [x] ETC: 디자인 이슈

## 🔔 관련된 이슈 넘버
close #134

## ✅ 작업 목록
### 가전 리스트 박스 윗부분 CSS 수정
- 위 상단바가 z-index가 더 높아 덮여서 잘리는 문제라, 박스 margin-top을 미세하게 줘서 안 잘리게 수정했습니다.
### global.css 수정
- 폰트 안 먹는 현상이 나타나서 하나씩 수정하다가 루트레이아웃에서 html은 variable, body는 className으로 속성을 주고
- global.css에서 body에 불필요하게 들어갔던 Arial, Helevetica, sans-serif는 일단 지웠습니다. -> 이걸 지우니 해결되네요!
- 그리고 일부 태그 (a, button 태그 등) 기본 속성과 함께 폰트 적용이 안되는 이슈가 있어서 수정하였습니다.

## 📷 ETC
<img width="366" alt="image" src="https://github.com/user-attachments/assets/94952795-7cf9-4b38-a644-bb2f38de6efe" />


